### PR TITLE
[BE] 회원 프로필 정보 조회/수정

### DIFF
--- a/backend/src/main/java/moim_today/application/file/AmazonS3Service.java
+++ b/backend/src/main/java/moim_today/application/file/AmazonS3Service.java
@@ -20,8 +20,8 @@ public class AmazonS3Service implements FileService{
         this.fileRemover = fileRemover;
     }
 
-    public FileInfoResponse uploadFile(final MemberSession memberSession, final MultipartFile multipartFile){
-        return fileUploader.uploadFile(memberSession, multipartFile);
+    public FileInfoResponse uploadFile(final String fileType, final MultipartFile multipartFile){
+        return fileUploader.uploadFile(fileType, multipartFile);
     }
 
     public void deleteFile(final MemberSession memberSession, final FileDeleteRequest fileDeleteRequest){

--- a/backend/src/main/java/moim_today/application/file/FileService.java
+++ b/backend/src/main/java/moim_today/application/file/FileService.java
@@ -7,7 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
 
-    FileInfoResponse uploadFile(final MemberSession memberSession, final MultipartFile multipartFile);
+    FileInfoResponse uploadFile(final String fileType, final MultipartFile multipartFile);
 
     void deleteFile(final MemberSession memberSession, final FileDeleteRequest fileDeleteRequest);
 }

--- a/backend/src/main/java/moim_today/application/member/MemberService.java
+++ b/backend/src/main/java/moim_today/application/member/MemberService.java
@@ -1,6 +1,7 @@
 package moim_today.application.member;
 
 import moim_today.domain.member.MemberSession;
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
 
@@ -9,4 +10,6 @@ public interface MemberService {
     void updatePassword(final MemberSession memberSession, final PasswordUpdateRequest passwordUpdateRequest);
 
     void recoverPassword(final PasswordRecoverRequest passwordRecoverRequest);
+
+    MemberProfileResponse getMemberProfile(final MemberSession memberSession);
 }

--- a/backend/src/main/java/moim_today/application/member/MemberService.java
+++ b/backend/src/main/java/moim_today/application/member/MemberService.java
@@ -5,6 +5,7 @@ import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.dto.member.ProfileUpdateRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
@@ -15,4 +16,6 @@ public interface MemberService {
     MemberProfileResponse getMemberProfile(final MemberSession memberSession);
 
     void updateProfile(final long memberId, final long universityId, final ProfileUpdateRequest profileUpdateRequest);
+
+    void updateProfileImage(final long memberId, final MultipartFile file);
 }

--- a/backend/src/main/java/moim_today/application/member/MemberService.java
+++ b/backend/src/main/java/moim_today/application/member/MemberService.java
@@ -4,6 +4,7 @@ import moim_today.domain.member.MemberSession;
 import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.dto.member.ProfileUpdateRequest;
 
 public interface MemberService {
 
@@ -12,4 +13,6 @@ public interface MemberService {
     void recoverPassword(final PasswordRecoverRequest passwordRecoverRequest);
 
     MemberProfileResponse getMemberProfile(final MemberSession memberSession);
+
+    void updateProfile(final long memberId, final long universityId, final ProfileUpdateRequest profileUpdateRequest);
 }

--- a/backend/src/main/java/moim_today/application/member/MemberServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/member/MemberServiceImpl.java
@@ -1,8 +1,10 @@
 package moim_today.application.member;
 
 import moim_today.domain.member.MemberSession;
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.implement.member.MemberFinder;
 import moim_today.implement.member.MemberUpdater;
 import org.springframework.stereotype.Service;
 
@@ -13,8 +15,12 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberUpdater memberUpdater;
 
-    public MemberServiceImpl(final MemberUpdater memberUpdater) {
+    private final MemberFinder memberFinder;
+
+    public MemberServiceImpl(final MemberUpdater memberUpdater,
+                             final MemberFinder memberFinder) {
         this.memberUpdater = memberUpdater;
+        this.memberFinder = memberFinder;
     }
 
     @Override
@@ -29,5 +35,10 @@ public class MemberServiceImpl implements MemberService {
                 passwordRecoverRequest.newPassword(),
                 LocalDateTime.now()
         );
+    }
+
+    @Override
+    public MemberProfileResponse getMemberProfile(final MemberSession memberSession) {
+        return memberFinder.getMemberProfile(memberSession.id());
     }
 }

--- a/backend/src/main/java/moim_today/application/member/MemberServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/member/MemberServiceImpl.java
@@ -1,15 +1,20 @@
 package moim_today.application.member;
 
 import moim_today.domain.member.MemberSession;
+import moim_today.dto.file.FileInfoResponse;
 import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.dto.member.ProfileUpdateRequest;
+import moim_today.implement.file.FileUploader;
 import moim_today.implement.member.MemberFinder;
 import moim_today.implement.member.MemberUpdater;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+
+import static moim_today.global.constant.FileTypeConstant.PROFILE_IMAGE;
 
 @Service
 public class MemberServiceImpl implements MemberService {
@@ -18,10 +23,14 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberFinder memberFinder;
 
+    private final FileUploader fileUploader;
+
     public MemberServiceImpl(final MemberUpdater memberUpdater,
-                             final MemberFinder memberFinder) {
+                             final MemberFinder memberFinder,
+                             final FileUploader fileUploader) {
         this.memberUpdater = memberUpdater;
         this.memberFinder = memberFinder;
+        this.fileUploader = fileUploader;
     }
 
     @Override
@@ -48,5 +57,11 @@ public class MemberServiceImpl implements MemberService {
                               final long universityId,
                               final ProfileUpdateRequest profileUpdateRequest) {
         memberUpdater.updateProfile(memberId, universityId, profileUpdateRequest);
+    }
+
+    @Override
+    public void updateProfileImage(final long memberId, final MultipartFile file) {
+        FileInfoResponse fileInfoResponse = fileUploader.uploadFile(PROFILE_IMAGE.value(), file);
+        memberUpdater.updateProfileImageUrl(memberId, fileInfoResponse.uploadFileUrl());
     }
 }

--- a/backend/src/main/java/moim_today/application/member/MemberServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/member/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import moim_today.domain.member.MemberSession;
 import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.implement.member.MemberFinder;
 import moim_today.implement.member.MemberUpdater;
 import org.springframework.stereotype.Service;
@@ -40,5 +41,12 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberProfileResponse getMemberProfile(final MemberSession memberSession) {
         return memberFinder.getMemberProfile(memberSession.id());
+    }
+
+    @Override
+    public void updateProfile(final long memberId,
+                              final long universityId,
+                              final ProfileUpdateRequest profileUpdateRequest) {
+        memberUpdater.updateProfile(memberId, universityId, profileUpdateRequest);
     }
 }

--- a/backend/src/main/java/moim_today/dto/member/MemberProfileResponse.java
+++ b/backend/src/main/java/moim_today/dto/member/MemberProfileResponse.java
@@ -1,0 +1,24 @@
+package moim_today.dto.member;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import moim_today.domain.member.enums.Gender;
+
+import java.time.LocalDate;
+
+@Builder
+public record MemberProfileResponse(
+        String universityName,
+        String departmentName,
+        String email,
+        String username,
+        String studentId,
+        LocalDate birthDate,
+        Gender gender,
+        String memberProfileImageUrl
+) {
+
+    @QueryProjection
+    public MemberProfileResponse {
+    }
+}

--- a/backend/src/main/java/moim_today/dto/member/ProfileUpdateRequest.java
+++ b/backend/src/main/java/moim_today/dto/member/ProfileUpdateRequest.java
@@ -1,0 +1,6 @@
+package moim_today.dto.member;
+
+public record ProfileUpdateRequest(
+        long departmentId
+) {
+}

--- a/backend/src/main/java/moim_today/global/constant/FileTypeConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/FileTypeConstant.java
@@ -1,0 +1,17 @@
+package moim_today.global.constant;
+
+public enum FileTypeConstant {
+
+    PROFILE_IMAGE("/profile"),
+    MOIM_IMAGE("moim");
+
+    private final String value;
+
+    FileTypeConstant(final String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/backend/src/main/java/moim_today/global/constant/FileTypeConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/FileTypeConstant.java
@@ -2,7 +2,7 @@ package moim_today.global.constant;
 
 public enum FileTypeConstant {
 
-    PROFILE_IMAGE("/profile"),
+    PROFILE_IMAGE("profile"),
     MOIM_IMAGE("moim");
 
     private final String value;

--- a/backend/src/main/java/moim_today/global/constant/exception/DepartmentExceptionConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/exception/DepartmentExceptionConstant.java
@@ -1,0 +1,17 @@
+package moim_today.global.constant.exception;
+
+public enum DepartmentExceptionConstant {
+
+    DEPARTMENT_NOT_FOUND_ERROR("존재하지 않는 전공입니다."),
+    DEPARTMENT_NOT_MATCH_UNIVERSITY("귀하의 학교에 존재하는 전공이 아닙니다.");
+
+    private final String message;
+
+    DepartmentExceptionConstant(final String message) {
+        this.message = message;
+    }
+
+    public String message() {
+        return message;
+    }
+}

--- a/backend/src/main/java/moim_today/implement/department/DepartmentFinder.java
+++ b/backend/src/main/java/moim_today/implement/department/DepartmentFinder.java
@@ -1,0 +1,25 @@
+package moim_today.implement.department;
+
+import moim_today.global.annotation.Implement;
+import moim_today.global.error.BadRequestException;
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
+import moim_today.persistence.repository.department.DepartmentRepository;
+
+import static moim_today.global.constant.exception.DepartmentExceptionConstant.DEPARTMENT_NOT_MATCH_UNIVERSITY;
+
+@Implement
+public class DepartmentFinder {
+
+    private final DepartmentRepository departmentRepository;
+
+    public DepartmentFinder(final DepartmentRepository departmentRepository) {
+        this.departmentRepository = departmentRepository;
+    }
+
+    public void validateDepartmentId(final long universityId, final long departmentId) {
+        DepartmentJpaEntity departmentJpaEntity = departmentRepository.getById(departmentId);
+        if (departmentJpaEntity.getUniversityId() != universityId) {
+            throw new BadRequestException(DEPARTMENT_NOT_MATCH_UNIVERSITY.message());
+        }
+    }
+}

--- a/backend/src/main/java/moim_today/implement/file/FileUploader.java
+++ b/backend/src/main/java/moim_today/implement/file/FileUploader.java
@@ -33,10 +33,9 @@ public class FileUploader {
         this.amazonS3 = amazonS3;
     }
 
-    public FileInfoResponse uploadFile(final MemberSession memberSession, final MultipartFile multipartFile) {
-        long memberId = memberSession.id();
-        long universityId = memberSession.universityId();
-        String uploadFolder = universityId+"/"+memberId;
+    public FileInfoResponse uploadFile(final String fileType, final MultipartFile multipartFile) {
+
+        String uploadFolder = fileType;
 
         String originalFileName = multipartFile.getOriginalFilename();
         String uploadFileName = createFileName(originalFileName);

--- a/backend/src/main/java/moim_today/implement/member/MemberFinder.java
+++ b/backend/src/main/java/moim_today/implement/member/MemberFinder.java
@@ -1,5 +1,6 @@
 package moim_today.implement.member;
 
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.persistence.repository.member.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,5 +17,10 @@ public class MemberFinder {
     @Transactional
     public void validateEmailExists(final String email) {
         memberRepository.validateEmailExists(email);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberProfileResponse getMemberProfile(final long memberId) {
+        return memberRepository.getMemberProfile(memberId);
     }
 }

--- a/backend/src/main/java/moim_today/implement/member/MemberUpdater.java
+++ b/backend/src/main/java/moim_today/implement/member/MemberUpdater.java
@@ -1,8 +1,10 @@
 package moim_today.implement.member;
 
 import moim_today.domain.certification_token.CertificationToken;
+import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.global.annotation.Implement;
 import moim_today.implement.certification_token.CertificationTokenFinder;
+import moim_today.implement.department.DepartmentFinder;
 import moim_today.persistence.entity.certification_token.CertificationTokenJpaEntity;
 import moim_today.persistence.entity.member.MemberJpaEntity;
 import moim_today.persistence.repository.member.MemberRepository;
@@ -16,13 +18,16 @@ public class MemberUpdater {
 
     private final MemberRepository memberRepository;
     private final CertificationTokenFinder certificationTokenFinder;
+    private final DepartmentFinder departmentFinder;
     private final PasswordEncoder passwordEncoder;
 
     public MemberUpdater(final MemberRepository memberRepository,
                          final CertificationTokenFinder certificationTokenFinder,
+                         final DepartmentFinder departmentFinder,
                          final PasswordEncoder passwordEncoder) {
         this.memberRepository = memberRepository;
         this.certificationTokenFinder = certificationTokenFinder;
+        this.departmentFinder = departmentFinder;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -47,5 +52,14 @@ public class MemberUpdater {
                                          final LocalDateTime now) {
         CertificationToken certificationToken = CertificationToken.toDomain(certificationTokenJpaEntity);
         certificationToken.validateExpiredDateTime(now);
+    }
+
+    @Transactional
+    public void updateProfile(final long memberId,
+                              final long universityId,
+                              final ProfileUpdateRequest profileUpdateRequest) {
+        MemberJpaEntity memberJpaEntity = memberRepository.getById(memberId);
+        departmentFinder.validateDepartmentId(universityId, profileUpdateRequest.departmentId());
+        memberJpaEntity.updateProfile(profileUpdateRequest.departmentId());
     }
 }

--- a/backend/src/main/java/moim_today/implement/member/MemberUpdater.java
+++ b/backend/src/main/java/moim_today/implement/member/MemberUpdater.java
@@ -62,4 +62,10 @@ public class MemberUpdater {
         departmentFinder.validateDepartmentId(universityId, profileUpdateRequest.departmentId());
         memberJpaEntity.updateProfile(profileUpdateRequest.departmentId());
     }
+
+    @Transactional
+    public void updateProfileImageUrl(final long memberId, final String profileImageUrl) {
+        MemberJpaEntity memberJpaEntity = memberRepository.getById(memberId);
+        memberJpaEntity.updateProfileImageUrl(profileImageUrl);
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/entity/member/MemberJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/member/MemberJpaEntity.java
@@ -65,4 +65,8 @@ public class MemberJpaEntity extends BaseTimeEntity {
     public void updateProfile(final long departmentId) {
         this.departmentId = departmentId;
     }
+
+    public void updateProfileImageUrl(final String profileImageUrl) {
+        this.memberProfileImageUrl = profileImageUrl;
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/entity/member/MemberJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/member/MemberJpaEntity.java
@@ -61,4 +61,8 @@ public class MemberJpaEntity extends BaseTimeEntity {
     public void updatePassword(final PasswordEncoder passwordEncoder, final String newPassword) {
         this.password = passwordEncoder.encode(newPassword);
     }
+
+    public void updateProfile(final long departmentId) {
+        this.departmentId = departmentId;
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepository.java
@@ -1,4 +1,8 @@
 package moim_today.persistence.repository.department;
 
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
+
 public interface DepartmentRepository {
+
+    void save(final DepartmentJpaEntity departmentJpaEntity);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepository.java
@@ -5,4 +5,6 @@ import moim_today.persistence.entity.department.DepartmentJpaEntity;
 public interface DepartmentRepository {
 
     void save(final DepartmentJpaEntity departmentJpaEntity);
+
+    DepartmentJpaEntity getById(final long departmentId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepositoryImpl.java
@@ -1,7 +1,10 @@
 package moim_today.persistence.repository.department;
 
+import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import org.springframework.stereotype.Repository;
+
+import static moim_today.global.constant.exception.DepartmentExceptionConstant.DEPARTMENT_NOT_FOUND_ERROR;
 
 @Repository
 public class DepartmentRepositoryImpl implements DepartmentRepository {
@@ -15,5 +18,11 @@ public class DepartmentRepositoryImpl implements DepartmentRepository {
     @Override
     public void save(final DepartmentJpaEntity departmentJpaEntity) {
         departmentJpaRepository.save(departmentJpaEntity);
+    }
+
+    @Override
+    public DepartmentJpaEntity getById(final long departmentId) {
+        return departmentJpaRepository.findById(departmentId)
+                .orElseThrow(() -> new NotFoundException(DEPARTMENT_NOT_FOUND_ERROR.message()));
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepositoryImpl.java
@@ -1,5 +1,6 @@
 package moim_today.persistence.repository.department;
 
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,5 +10,10 @@ public class DepartmentRepositoryImpl implements DepartmentRepository {
 
     public DepartmentRepositoryImpl(final DepartmentJpaRepository departmentJpaRepository) {
         this.departmentJpaRepository = departmentJpaRepository;
+    }
+
+    @Override
+    public void save(final DepartmentJpaEntity departmentJpaEntity) {
+        departmentJpaRepository.save(departmentJpaEntity);
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/member/MemberRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package moim_today.persistence.repository.member;
 
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.persistence.entity.member.MemberJpaEntity;
 
 public interface MemberRepository {
@@ -11,4 +12,6 @@ public interface MemberRepository {
     void validateEmailExists(final String email);
 
     MemberJpaEntity getById(final long memberId);
+
+    MemberProfileResponse getMemberProfile(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/member/MemberRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/member/MemberRepositoryImpl.java
@@ -1,18 +1,30 @@
 package moim_today.persistence.repository.member;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import moim_today.dto.member.MemberProfileResponse;
+import moim_today.dto.member.QMemberProfileResponse;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.member.MemberJpaEntity;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 import static moim_today.global.constant.exception.MemberExceptionConstant.*;
+import static moim_today.persistence.entity.department.QDepartmentJpaEntity.departmentJpaEntity;
+import static moim_today.persistence.entity.member.QMemberJpaEntity.memberJpaEntity;
+import static moim_today.persistence.entity.university.QUniversityJpaEntity.universityJpaEntity;
 
 @Repository
 public class MemberRepositoryImpl implements MemberRepository {
 
     private final MemberJpaRepository memberJpaRepository;
 
-    public MemberRepositoryImpl(final MemberJpaRepository memberJpaRepository) {
+    private final JPAQueryFactory queryFactory;
+
+    public MemberRepositoryImpl(final MemberJpaRepository memberJpaRepository,
+                                final JPAQueryFactory queryFactory) {
         this.memberJpaRepository = memberJpaRepository;
+        this.queryFactory = queryFactory;
     }
 
     @Override
@@ -35,6 +47,26 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public MemberJpaEntity getById(final long memberId) {
         return memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND_ERROR.message()));
+    }
+
+    @Override
+    public MemberProfileResponse getMemberProfile(final long memberId) {
+        return queryFactory.select(new QMemberProfileResponse(
+                        universityJpaEntity.universityName,
+                        departmentJpaEntity.departmentName,
+                        memberJpaEntity.email,
+                        memberJpaEntity.username,
+                        memberJpaEntity.studentId,
+                        memberJpaEntity.birthDate,
+                        memberJpaEntity.gender,
+                        memberJpaEntity.memberProfileImageUrl
+                ))
+                .from(memberJpaEntity)
+                .join(universityJpaEntity).on(memberJpaEntity.universityId.eq(universityJpaEntity.id))
+                .join(departmentJpaEntity).on(memberJpaEntity.departmentId.eq(departmentJpaEntity.id))
+                .where(memberJpaEntity.id.eq(memberId))
+                .stream().findAny()
                 .orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND_ERROR.message()));
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepository.java
@@ -1,4 +1,8 @@
 package moim_today.persistence.repository.university;
 
+import moim_today.persistence.entity.university.UniversityJpaEntity;
+
 public interface UniversityRepository {
+
+    void save(final UniversityJpaEntity universityJpaEntity);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
@@ -1,5 +1,6 @@
 package moim_today.persistence.repository.university;
 
+import moim_today.persistence.entity.university.UniversityJpaEntity;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,5 +10,10 @@ public class UniversityRepositoryImpl implements UniversityRepository {
 
     public UniversityRepositoryImpl(final UniversityJpaRepository universityJpaRepository) {
         this.universityJpaRepository = universityJpaRepository;
+    }
+
+    @Override
+    public void save(final UniversityJpaEntity universityJpaEntity) {
+        universityJpaRepository.save(universityJpaEntity);
     }
 }

--- a/backend/src/main/java/moim_today/presentation/auth/AuthController.java
+++ b/backend/src/main/java/moim_today/presentation/auth/AuthController.java
@@ -18,7 +18,7 @@ public class AuthController {
         this.authService = authService;
     }
 
-    @PostMapping("/auth")
+    @PostMapping("/login")
     public void login(@RequestBody final MemberLoginRequest memberLoginRequest,
                       final HttpServletRequest request) {
         authService.login(memberLoginRequest, request);

--- a/backend/src/main/java/moim_today/presentation/file/FileController.java
+++ b/backend/src/main/java/moim_today/presentation/file/FileController.java
@@ -5,8 +5,11 @@ import moim_today.domain.member.MemberSession;
 import moim_today.dto.file.FileDeleteRequest;
 import moim_today.dto.file.FileInfoResponse;
 import moim_today.global.annotation.Login;
+import moim_today.global.constant.FileTypeConstant;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import static moim_today.global.constant.FileTypeConstant.*;
 
 @RestController
 @RequestMapping("/api")
@@ -21,7 +24,7 @@ public class FileController {
     @PostMapping(value = "/files")
     public FileInfoResponse uploadFile(@Login final MemberSession memberSession,
                                        @RequestPart final MultipartFile file) {
-        return fileService.uploadFile(memberSession, file);
+        return fileService.uploadFile(PROFILE_IMAGE.value(), file);
     }
 
     @DeleteMapping("/files")

--- a/backend/src/main/java/moim_today/presentation/member/MemberController.java
+++ b/backend/src/main/java/moim_today/presentation/member/MemberController.java
@@ -5,6 +5,7 @@ import moim_today.domain.member.MemberSession;
 import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.global.annotation.Login;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,5 +33,11 @@ public class MemberController {
     @GetMapping("/profile")
     public MemberProfileResponse getMemberProfile(@Login final MemberSession memberSession) {
         return memberService.getMemberProfile(memberSession);
+    }
+
+    @PatchMapping("/profile")
+    public void updateProfile(@Login final MemberSession memberSession,
+                              @RequestBody final ProfileUpdateRequest profileUpdateRequest) {
+        memberService.updateProfile(memberSession.id(), memberSession.universityId(), profileUpdateRequest);
     }
 }

--- a/backend/src/main/java/moim_today/presentation/member/MemberController.java
+++ b/backend/src/main/java/moim_today/presentation/member/MemberController.java
@@ -8,6 +8,7 @@ import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.global.annotation.Login;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/api/members")
 @RestController
@@ -39,5 +40,11 @@ public class MemberController {
     public void updateProfile(@Login final MemberSession memberSession,
                               @RequestBody final ProfileUpdateRequest profileUpdateRequest) {
         memberService.updateProfile(memberSession.id(), memberSession.universityId(), profileUpdateRequest);
+    }
+
+    @PatchMapping("/profile-image")
+    public void updateProfileImage(@Login final MemberSession memberSession,
+                                   @RequestPart final MultipartFile file) {
+        memberService.updateProfileImage(memberSession.id(), file);
     }
 }

--- a/backend/src/main/java/moim_today/presentation/member/MemberController.java
+++ b/backend/src/main/java/moim_today/presentation/member/MemberController.java
@@ -2,6 +2,7 @@ package moim_today.presentation.member;
 
 import moim_today.application.member.MemberService;
 import moim_today.domain.member.MemberSession;
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.global.annotation.Login;
@@ -26,5 +27,10 @@ public class MemberController {
     public void updatePassword(@Login final MemberSession memberSession,
                                @RequestBody final PasswordUpdateRequest passwordUpdateRequest) {
         memberService.updatePassword(memberSession, passwordUpdateRequest);
+    }
+
+    @GetMapping("/profile")
+    public MemberProfileResponse getMemberProfile(@Login final MemberSession memberSession) {
+        return memberService.getMemberProfile(memberSession);
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/file/FakeFileService.java
+++ b/backend/src/test/java/moim_today/fake_class/file/FakeFileService.java
@@ -9,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class FakeFileService implements FileService {
 
     @Override
-    public FileInfoResponse uploadFile(final MemberSession memberSession, final MultipartFile multipartFile) {
+    public FileInfoResponse uploadFile(final String fileType, final MultipartFile multipartFile) {
         return new FileInfoResponse("testUploadFileUrl");
     }
 

--- a/backend/src/test/java/moim_today/fake_class/member/FakeMemberService.java
+++ b/backend/src/test/java/moim_today/fake_class/member/FakeMemberService.java
@@ -9,6 +9,7 @@ import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.fake_DB.FakeMemberSession;
 import moim_today.global.error.NotFoundException;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -51,6 +52,11 @@ public class FakeMemberService implements MemberService {
 
     @Override
     public void updateProfile(final long memberId, final long universityId, final ProfileUpdateRequest profileUpdateRequest) {
+
+    }
+
+    @Override
+    public void updateProfileImage(final long memberId, final MultipartFile file) {
 
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/member/FakeMemberService.java
+++ b/backend/src/test/java/moim_today/fake_class/member/FakeMemberService.java
@@ -6,6 +6,7 @@ import moim_today.domain.member.enums.Gender;
 import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.fake_DB.FakeMemberSession;
 import moim_today.global.error.NotFoundException;
 
@@ -46,5 +47,10 @@ public class FakeMemberService implements MemberService {
                 .gender(Gender.MALE)
                 .memberProfileImageUrl("testUrl")
                 .build();
+    }
+
+    @Override
+    public void updateProfile(final long memberId, final long universityId, final ProfileUpdateRequest profileUpdateRequest) {
+
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/member/FakeMemberService.java
+++ b/backend/src/test/java/moim_today/fake_class/member/FakeMemberService.java
@@ -2,13 +2,19 @@ package moim_today.fake_class.member;
 
 import moim_today.application.member.MemberService;
 import moim_today.domain.member.MemberSession;
+import moim_today.domain.member.enums.Gender;
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.fake_DB.FakeMemberSession;
 import moim_today.global.error.NotFoundException;
-import moim_today.util.TestConstant;
+
+import java.time.LocalDate;
 
 import static moim_today.global.constant.exception.MailExceptionConstant.MAIL_CERTIFICATION_TOKEN_NOT_FOUND_ERROR;
-import static moim_today.util.TestConstant.*;
+import static moim_today.global.constant.exception.MemberExceptionConstant.MEMBER_NOT_FOUND_ERROR;
+import static moim_today.util.TestConstant.CERTIFICATION_TOKEN;
+import static moim_today.util.TestConstant.EMAIL;
 
 
 public class FakeMemberService implements MemberService {
@@ -23,5 +29,22 @@ public class FakeMemberService implements MemberService {
         if (!passwordRecoverRequest.passwordToken().equals(CERTIFICATION_TOKEN.value())) {
             throw new NotFoundException(MAIL_CERTIFICATION_TOKEN_NOT_FOUND_ERROR.message());
         }
+    }
+
+    @Override
+    public MemberProfileResponse getMemberProfile(final MemberSession memberSession) {
+        if (memberSession.id() != FakeMemberSession.createMemberSession().id()) {
+            throw new NotFoundException(MEMBER_NOT_FOUND_ERROR.message());
+        }
+        return MemberProfileResponse.builder()
+                .universityName("universityName")
+                .departmentName("departmentName")
+                .email(EMAIL.value())
+                .username("username")
+                .studentId("studenId")
+                .birthDate(LocalDate.of(2000, 12, 18))
+                .gender(Gender.MALE)
+                .memberProfileImageUrl("testUrl")
+                .build();
     }
 }

--- a/backend/src/test/java/moim_today/global/response/CollectionResponseTest.java
+++ b/backend/src/test/java/moim_today/global/response/CollectionResponseTest.java
@@ -3,23 +3,28 @@ package moim_today.global.response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+
+import static moim_today.util.TestConstant.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CollectionResponseTest {
     
-    @DisplayName("ApiResponse에 데이터가 올바르게 들어가는지 확인합니다.")
+    @DisplayName("CollectionResponse에 데이터가 올바르게 들어가는지 확인합니다.")
     @Test
     void ApiResponse_테스트(){
         //given
-        Member member = new Member("testMember", 25);
+        ArrayList<Member> members = new ArrayList<>();
+        Member memberA = new Member(USERNAME.value(), 25);
+        Member memberB = new Member(USERNAME.value(), 30);
+        members.add(memberA);
+        members.add(memberB);
 
         //when
-        CollectionResponse<Member> memberCollectionResponse = CollectionResponse.of(member);
+        CollectionResponse<ArrayList<Member>> arrayListCollectionResponse = CollectionResponse.of(members);
 
         //then
-        assertThat(memberCollectionResponse.data()).isEqualTo(member);
-        assertThat(memberCollectionResponse.data().getName()).isEqualTo("testMember");
-        assertThat(memberCollectionResponse.data().getAge()).isEqualTo(25);
+        assertThat(arrayListCollectionResponse.data()).contains(memberA, memberB);
     }
 
     static class Member{
@@ -29,14 +34,6 @@ class CollectionResponseTest {
         public Member(final String name, final int age) {
             this.name = name;
             this.age = age;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public int getAge() {
-            return age;
         }
     }
 }

--- a/backend/src/test/java/moim_today/global/response/ErrorResponseTest.java
+++ b/backend/src/test/java/moim_today/global/response/ErrorResponseTest.java
@@ -3,6 +3,8 @@ package moim_today.global.response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static moim_today.util.TestConstant.MESSAGE;
+import static moim_today.util.TestConstant.STATUS_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ErrorResponseTest {
@@ -11,8 +13,8 @@ class ErrorResponseTest {
     @Test
     void ErrorResponse_테스트(){
         //given
-        String statusCode = "200";
-        String message = "SUCCESS";
+        String statusCode = STATUS_CODE.value();
+        String message = MESSAGE.value();
 
         //when
         ErrorResponse errorResponse = ErrorResponse.of(statusCode, message);

--- a/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 
 import static moim_today.global.constant.exception.MemberExceptionConstant.EMAIL_NOT_FOUND_ERROR;
 import static moim_today.global.constant.exception.MemberExceptionConstant.MEMBER_NOT_FOUND_ERROR;
-import static moim_today.util.TestConstant.EMAIL;
+import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 class MemberFinderTest extends ImplementTest {
@@ -52,7 +52,7 @@ class MemberFinderTest extends ImplementTest {
     void getProfileByMemberId() {
         // given1
         UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
-                .universityName("universityName")
+                .universityName(UNIVERSITY_NAME.value())
                 .build();
 
         universityRepository.save(universityJpaEntity);
@@ -60,7 +60,7 @@ class MemberFinderTest extends ImplementTest {
 
         // given2
         DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
-                .departmentName("departmentName")
+                .departmentName(DEPARTMENT_NAME.value())
                 .universityId(universityId)
                 .build();
 
@@ -72,11 +72,11 @@ class MemberFinderTest extends ImplementTest {
                 .universityId(universityId)
                 .departmentId(departmentId)
                 .email(EMAIL.value())
-                .username("username")
-                .studentId("studentId")
+                .username(USERNAME.value())
+                .studentId(STUDENT_ID.value())
                 .birthDate(LocalDate.of(2000, 12, 18))
                 .gender(Gender.MALE)
-                .memberProfileImageUrl("testUrl")
+                .memberProfileImageUrl(PROFILE_IMAGE_URL.value())
                 .build();
 
         memberRepository.save(memberJpaEntity);
@@ -86,14 +86,14 @@ class MemberFinderTest extends ImplementTest {
         MemberProfileResponse memberProfileResponse = memberFinder.getMemberProfile(memberId);
 
         // then
-        assertThat(memberProfileResponse.universityName()).isEqualTo("universityName");
-        assertThat(memberProfileResponse.departmentName()).isEqualTo("departmentName");
+        assertThat(memberProfileResponse.universityName()).isEqualTo(UNIVERSITY_NAME.value());
+        assertThat(memberProfileResponse.departmentName()).isEqualTo(DEPARTMENT_NAME.value());
         assertThat(memberProfileResponse.email()).isEqualTo(EMAIL.value());
-        assertThat(memberProfileResponse.username()).isEqualTo("username");
-        assertThat(memberProfileResponse.studentId()).isEqualTo("studentId");
-        assertThat(memberProfileResponse.birthDate()).isEqualTo("2000-12-18");
+        assertThat(memberProfileResponse.username()).isEqualTo(USERNAME.value());
+        assertThat(memberProfileResponse.studentId()).isEqualTo(STUDENT_ID.value());
+        assertThat(memberProfileResponse.birthDate()).isEqualTo(LocalDate.of(2000,12,18));
         assertThat(memberProfileResponse.gender()).isEqualTo(Gender.MALE);
-        assertThat(memberProfileResponse.memberProfileImageUrl()).isEqualTo("testUrl");
+        assertThat(memberProfileResponse.memberProfileImageUrl()).isEqualTo(PROFILE_IMAGE_URL.value());
     }
 
     @DisplayName("memberId로 프로필 조회 실패시 프로필 예외가 발생한다.")

--- a/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
@@ -1,14 +1,22 @@
 package moim_today.implement.member;
 
+import moim_today.domain.member.enums.Gender;
+import moim_today.dto.member.MemberProfileResponse;
 import moim_today.global.error.NotFoundException;
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import moim_today.persistence.entity.member.MemberJpaEntity;
+import moim_today.persistence.entity.university.UniversityJpaEntity;
 import moim_today.util.ImplementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
+
 import static moim_today.global.constant.exception.MemberExceptionConstant.EMAIL_NOT_FOUND_ERROR;
+import static moim_today.global.constant.exception.MemberExceptionConstant.MEMBER_NOT_FOUND_ERROR;
 import static moim_today.util.TestConstant.EMAIL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MemberFinderTest extends ImplementTest {
@@ -37,5 +45,56 @@ class MemberFinderTest extends ImplementTest {
 
         // when && then
         memberFinder.validateEmailExists(EMAIL.value());
+    }
+
+    @DisplayName("memberId로 프로필 조회 성공시 프로필 정보를 반환한다.")
+    @Test
+    void getProfileByMemberId() {
+        // given
+        UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
+                .universityName("universityName")
+                .build();
+
+        DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
+                .departmentName("departmentName")
+                .universityId(1L)
+                .build();
+
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .universityId(1L)
+                .departmentId(1L)
+                .email(EMAIL.value())
+                .username("username")
+                .studentId("studentId")
+                .birthDate(LocalDate.of(2000, 12, 18))
+                .gender(Gender.MALE)
+                .memberProfileImageUrl("testUrl")
+                .build();
+
+        universityRepository.save(universityJpaEntity);
+        departmentRepository.save(departmentJpaEntity);
+        memberRepository.save(memberJpaEntity);
+
+        // when
+        MemberProfileResponse memberProfileResponse = memberFinder.getMemberProfile(memberJpaEntity.getId());
+
+        // then
+        assertThat(memberProfileResponse.universityName()).isEqualTo("universityName");
+        assertThat(memberProfileResponse.departmentName()).isEqualTo("departmentName");
+        assertThat(memberProfileResponse.email()).isEqualTo(EMAIL.value());
+        assertThat(memberProfileResponse.username()).isEqualTo("username");
+        assertThat(memberProfileResponse.studentId()).isEqualTo("studentId");
+        assertThat(memberProfileResponse.birthDate()).isEqualTo("2000-12-18");
+        assertThat(memberProfileResponse.gender()).isEqualTo(Gender.MALE);
+        assertThat(memberProfileResponse.memberProfileImageUrl()).isEqualTo("testUrl");
+    }
+
+    @DisplayName("memberId로 프로필 조회 실패시 프로필 예외가 발생한다.")
+    @Test
+    void getProfileByWrongMemberId() {
+        // expected
+        assertThatThrownBy(() -> memberFinder.getMemberProfile(1L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(MEMBER_NOT_FOUND_ERROR.message());
     }
 }

--- a/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static moim_today.global.constant.exception.MemberExceptionConstant.EMAIL_NOT_FOUND_ERROR;
 import static moim_today.global.constant.exception.MemberExceptionConstant.MEMBER_NOT_FOUND_ERROR;
 import static moim_today.util.TestConstant.EMAIL;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 class MemberFinderTest extends ImplementTest {
 
@@ -50,19 +50,27 @@ class MemberFinderTest extends ImplementTest {
     @DisplayName("memberId로 프로필 조회 성공시 프로필 정보를 반환한다.")
     @Test
     void getProfileByMemberId() {
-        // given
+        // given1
         UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
                 .universityName("universityName")
                 .build();
 
+        universityRepository.save(universityJpaEntity);
+        long universityId = universityJpaEntity.getId();
+
+        // given2
         DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
                 .departmentName("departmentName")
-                .universityId(1L)
+                .universityId(universityId)
                 .build();
 
+        departmentRepository.save(departmentJpaEntity);
+        long departmentId = departmentJpaEntity.getId();
+
+        // given3
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
-                .universityId(1L)
-                .departmentId(1L)
+                .universityId(universityId)
+                .departmentId(departmentId)
                 .email(EMAIL.value())
                 .username("username")
                 .studentId("studentId")
@@ -71,12 +79,11 @@ class MemberFinderTest extends ImplementTest {
                 .memberProfileImageUrl("testUrl")
                 .build();
 
-        universityRepository.save(universityJpaEntity);
-        departmentRepository.save(departmentJpaEntity);
         memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
 
         // when
-        MemberProfileResponse memberProfileResponse = memberFinder.getMemberProfile(memberJpaEntity.getId());
+        MemberProfileResponse memberProfileResponse = memberFinder.getMemberProfile(memberId);
 
         // then
         assertThat(memberProfileResponse.universityName()).isEqualTo("universityName");

--- a/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
@@ -153,10 +153,11 @@ class MemberUpdaterTest extends ImplementTest {
 
         departmentRepository.save(departmentJpaEntity);
         long updateDepartmentId = departmentJpaEntity.getId();
+        long departmentId = updateDepartmentId + 1L;
 
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
                 .universityId(universityId)
-                .departmentId(updateDepartmentId)
+                .departmentId(departmentId)
                 .build();
 
         memberRepository.save(memberJpaEntity);

--- a/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
@@ -169,4 +169,23 @@ class MemberUpdaterTest extends ImplementTest {
         MemberJpaEntity findEntity = memberRepository.getById(memberId);
         assertThat(findEntity.getDepartmentId()).isEqualTo(updateDepartmentId);
     }
+
+    @DisplayName("파일을 업로드하여 받아온 URL을 회원 프로필 URL에 업데이트 한다.")
+    @Test
+    void updateProfileUrl() {
+        //given
+        String updateProfileUrl = "updateProfileUrl";
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
+
+        //when
+        memberUpdater.updateProfileImageUrl(memberId, updateProfileUrl);
+
+        //then
+        MemberJpaEntity entity = memberRepository.getById(memberId);
+        assertThat(entity.getMemberProfileImageUrl()).isEqualTo(updateProfileUrl);
+    }
 }

--- a/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
@@ -1,11 +1,12 @@
 package moim_today.implement.member;
 
+import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.global.error.BadRequestException;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.certification_token.CertificationTokenJpaEntity;
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import moim_today.persistence.entity.member.MemberJpaEntity;
 import moim_today.util.ImplementTest;
-import moim_today.util.TestConstant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,8 @@ import java.time.LocalDateTime;
 import static moim_today.global.constant.exception.CertificationConstant.CERTIFICATION_EXPIRED_ERROR;
 import static moim_today.global.constant.exception.MailExceptionConstant.MAIL_CERTIFICATION_TOKEN_NOT_FOUND_ERROR;
 import static moim_today.util.TestConstant.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MemberUpdaterTest extends ImplementTest {
 
@@ -136,5 +138,35 @@ class MemberUpdaterTest extends ImplementTest {
         )
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(CERTIFICATION_EXPIRED_ERROR.message());
+    }
+
+    @DisplayName("사용자가 입력한 프로필 정보로 사용자 정보를 수정한다.")
+    @Test
+    void updateProfile() {
+        // given
+        long universityId = 1L;
+        long departmentId = 2L;
+
+        DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
+                .universityId(universityId)
+                .build();
+
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .universityId(universityId)
+                .departmentId(departmentId)
+                .build();
+
+        departmentRepository.save(departmentJpaEntity);
+        memberRepository.save(memberJpaEntity);
+        long updateDepartmentId = departmentJpaEntity.getId();
+        long memberId = memberJpaEntity.getId();
+        ProfileUpdateRequest profileUpdateRequest = new ProfileUpdateRequest(updateDepartmentId);
+
+        // when
+        memberUpdater.updateProfile(memberId, universityId, profileUpdateRequest);
+
+        // then
+        MemberJpaEntity findEntity = memberRepository.getById(memberId);
+        assertThat(findEntity.getDepartmentId()).isEqualTo(updateDepartmentId);
     }
 }

--- a/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 
 import static moim_today.global.constant.exception.CertificationConstant.CERTIFICATION_EXPIRED_ERROR;
+import static moim_today.global.constant.exception.DepartmentExceptionConstant.DEPARTMENT_NOT_MATCH_UNIVERSITY;
 import static moim_today.global.constant.exception.MailExceptionConstant.MAIL_CERTIFICATION_TOKEN_NOT_FOUND_ERROR;
 import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -145,20 +146,20 @@ class MemberUpdaterTest extends ImplementTest {
     void updateProfile() {
         // given
         long universityId = 1L;
-        long departmentId = 2L;
 
         DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
                 .universityId(universityId)
                 .build();
 
+        departmentRepository.save(departmentJpaEntity);
+        long updateDepartmentId = departmentJpaEntity.getId();
+
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
                 .universityId(universityId)
-                .departmentId(departmentId)
+                .departmentId(updateDepartmentId)
                 .build();
 
-        departmentRepository.save(departmentJpaEntity);
         memberRepository.save(memberJpaEntity);
-        long updateDepartmentId = departmentJpaEntity.getId();
         long memberId = memberJpaEntity.getId();
         ProfileUpdateRequest profileUpdateRequest = new ProfileUpdateRequest(updateDepartmentId);
 

--- a/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
@@ -205,7 +205,7 @@ class MemberUpdaterTest extends ImplementTest {
     @Test
     void updateProfileUrl() {
         //given
-        String updateProfileUrl = "updateProfileUrl";
+        String updateProfileUrl = PROFILE_IMAGE_URL.value();
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
                 .build();
 

--- a/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberUpdaterTest.java
@@ -171,6 +171,36 @@ class MemberUpdaterTest extends ImplementTest {
         assertThat(findEntity.getDepartmentId()).isEqualTo(updateDepartmentId);
     }
 
+    @DisplayName("사용자의 대학교에 수정 요청한 전공 ID가 없을 경우 예외를 발생시킨다.")
+    @Test
+    void updateProfileNotMatchUniversity() {
+        // given
+        long universityId_1 = 1L;
+        long universityId_2 = 2L;
+
+        DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
+                .universityId(universityId_1)
+                .build();
+
+        departmentRepository.save(departmentJpaEntity);
+        long updateDepartmentId = departmentJpaEntity.getId();
+
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .universityId(universityId_2)
+                .departmentId(updateDepartmentId)
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
+
+        ProfileUpdateRequest profileUpdateRequest = new ProfileUpdateRequest(updateDepartmentId);
+
+        // when & then
+        assertThatThrownBy(() -> memberUpdater.updateProfile(memberId, universityId_2, profileUpdateRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(DEPARTMENT_NOT_MATCH_UNIVERSITY.message());
+    }
+
     @DisplayName("파일을 업로드하여 받아온 URL을 회원 프로필 URL에 업데이트 한다.")
     @Test
     void updateProfileUrl() {

--- a/backend/src/test/java/moim_today/persistence/entity/member/MemberJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/member/MemberJpaEntityTest.java
@@ -52,7 +52,7 @@ class MemberJpaEntityTest {
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
                 .build();
 
-        String updateProfileUrl = "updateProfileUrl";
+        String updateProfileUrl = PROFILE_IMAGE_URL.value();
 
         // when
         memberJpaEntity.updateProfileImageUrl(updateProfileUrl);

--- a/backend/src/test/java/moim_today/persistence/entity/member/MemberJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/member/MemberJpaEntityTest.java
@@ -28,4 +28,36 @@ class MemberJpaEntityTest {
         boolean isMatched = passwordEncoder.matches(NEW_PASSWORD.value(), memberJpaEntity.getPassword());
         assertThat(isMatched).isTrue();
     }
+
+    @DisplayName("사용자가 입력한 프로필 정보로 프로필을 수정한다.")
+    @Test
+    void updateProfile() {
+        // given
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        long updateDepartmentId = 1L;
+
+        // when
+        memberJpaEntity.updateProfile(updateDepartmentId);
+
+        // then
+        assertThat(memberJpaEntity.getDepartmentId()).isEqualTo(updateDepartmentId);
+    }
+
+    @DisplayName("사용자가 업로드한 프로필 이미지의 URL로 수정한다.")
+    @Test
+    void updateProfileUrl() {
+        // given
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        String updateProfileUrl = "updateProfileUrl";
+
+        // when
+        memberJpaEntity.updateProfileImageUrl(updateProfileUrl);
+
+        // then
+        assertThat(memberJpaEntity.getMemberProfileImageUrl()).isEqualTo(updateProfileUrl);
+    }
 }

--- a/backend/src/test/java/moim_today/presentation/auth/AuthControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/auth/AuthControllerTest.java
@@ -32,15 +32,15 @@ class AuthControllerTest extends ControllerTest {
         MemberLoginRequest memberLoginRequest = new MemberLoginRequest(EMAIL.value(), PASSWORD.value());
         String json = objectMapper.writeValueAsString(memberLoginRequest);
 
-        mockMvc.perform(post("/api/auth")
+        mockMvc.perform(post("/api/login")
                         .contentType(APPLICATION_JSON)
                         .content(json)
                 )
                 .andExpect(status().isOk())
-                .andDo(document("로그인 성공 템플릿 API",
+                .andDo(document("로그인 성공",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("로그인")
-                                .summary("로그인 성공 템플릿")
+                                .summary("로그인")
                                 .requestFields(
                                         fieldWithPath("email").type(STRING).description("이메일"),
                                         fieldWithPath("password").type(STRING).description("비밀번호")
@@ -55,15 +55,15 @@ class AuthControllerTest extends ControllerTest {
         MemberLoginRequest memberLoginRequest = new MemberLoginRequest(WRONG_EMAIL.value(), WRONG_PASSWORD.value());
         String json = objectMapper.writeValueAsString(memberLoginRequest);
 
-        mockMvc.perform(post("/api/auth")
+        mockMvc.perform(post("/api/login")
                         .contentType(APPLICATION_JSON)
                         .content(json)
                 )
                 .andExpect(status().isNotFound())
-                .andDo(document("로그인 실패 템플릿 API",
+                .andDo(document("로그인 실패",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("로그인")
-                                .summary("로그인 실패 템플릿")
+                                .summary("로그인")
                                 .requestFields(
                                         fieldWithPath("email").type(STRING).description("이메일"),
                                         fieldWithPath("password").type(STRING).description("비밀번호")

--- a/backend/src/test/java/moim_today/presentation/file/FileControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/file/FileControllerTest.java
@@ -41,7 +41,8 @@ class FileControllerTest extends ControllerTest {
                 .andDo(document("파일 업로드",
                         requestParts(
                                 partWithName("file").description("업로드할 파일")
-                )));
+                        )
+                ));
     }
 
     @DisplayName("파일 삭제 테스트")

--- a/backend/src/test/java/moim_today/presentation/file/FileControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/file/FileControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static moim_today.util.TestConstant.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
@@ -30,7 +31,12 @@ class FileControllerTest extends ControllerTest {
     @Test
     void uploadFileTest() throws Exception {
 
-        MockMultipartFile file1 = new MockMultipartFile("file", "file1.txt", MediaType.TEXT_PLAIN_VALUE, "Test File 1".getBytes());
+        MockMultipartFile file1 = new MockMultipartFile(
+                FILE_NAME.value(),
+                ORIGINAL_FILE_NAME.value(),
+                MediaType.TEXT_PLAIN_VALUE,
+                FILE_CONTENT.value().getBytes()
+        );
 
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.POST, "/api/files")

--- a/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
@@ -2,22 +2,18 @@ package moim_today.presentation.member;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import moim_today.application.member.MemberService;
-import moim_today.domain.member.MemberSession;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.dto.member.ProfileUpdateRequest;
-import moim_today.fake_DB.FakeMemberSession;
 import moim_today.fake_class.member.FakeMemberService;
 import moim_today.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static moim_today.global.constant.MemberSessionConstant.MEMBER_SESSION;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
@@ -96,12 +92,8 @@ class MemberControllerTest extends ControllerTest {
     void updatePassword() throws Exception {
         PasswordUpdateRequest passwordUpdateRequest = new PasswordUpdateRequest(NEW_PASSWORD.value());
         String json = objectMapper.writeValueAsString(passwordUpdateRequest);
-        MockHttpSession session = new MockHttpSession();
-        MemberSession memberSession = FakeMemberSession.createMemberSession();
-        session.setAttribute(MEMBER_SESSION.value(), objectMapper.writeValueAsString(memberSession));
 
         mockMvc.perform(patch("/api/members/password")
-                        .session(session)
                         .contentType(APPLICATION_JSON)
                         .content(json)
                 )
@@ -120,13 +112,8 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("프로필을 조회에 성공한다.")
     @Test
     void getMemberProfile() throws Exception {
-        MockHttpSession session = new MockHttpSession();
-        MemberSession memberSession = FakeMemberSession.createMemberSession();
-        session.setAttribute(MEMBER_SESSION.value(), objectMapper.writeValueAsString(memberSession));
 
-        mockMvc.perform(get("/api/members/profile")
-                        .session(session)
-                )
+        mockMvc.perform(get("/api/members/profile"))
                 .andExpect(status().isOk())
                 .andDo(document("프로필 조회 성공",
                         resource(ResourceSnippetParameters.builder()
@@ -149,14 +136,10 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("프로필을 정보를 수정한다.")
     @Test
     void updateProfile() throws Exception {
-        MockHttpSession session = new MockHttpSession();
-        MemberSession memberSession = FakeMemberSession.createMemberSession();
-        session.setAttribute(MEMBER_SESSION.value(), objectMapper.writeValueAsString(memberSession));
         ProfileUpdateRequest profileUpdateRequest = new ProfileUpdateRequest(1L);
         String json = objectMapper.writeValueAsString(profileUpdateRequest);
 
         mockMvc.perform(patch("/api/members/profile")
-                        .session(session)
                         .contentType(APPLICATION_JSON)
                         .content(json)
                 )
@@ -176,14 +159,13 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("프로필 이미지를 수정하면 회원의 프로필 이미지 URL 정보가 변경된다.")
     @Test
     void updateProfileImage() throws Exception {
-        //given
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "filename.txt",
                 TEXT_PLAIN_VALUE,
-                "content".getBytes());
+                "content".getBytes()
+        );
 
-        //when & then
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.PATCH, "/api/members/profile-image")
                         .file(file)

--- a/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
@@ -153,17 +153,16 @@ class MemberControllerTest extends ControllerTest {
                                 )
                                 .build()
                         )));
-
     }
 
     @DisplayName("프로필 이미지를 수정하면 회원의 프로필 이미지 URL 정보가 변경된다.")
     @Test
     void updateProfileImage() throws Exception {
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "filename.txt",
+                FILE_NAME.value(),
+                ORIGINAL_FILE_NAME.value(),
                 TEXT_PLAIN_VALUE,
-                "content".getBytes()
+                FILE_CONTENT.value().getBytes()
         );
 
         mockMvc.perform(MockMvcRequestBuilders

--- a/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
@@ -5,6 +5,7 @@ import moim_today.application.member.MemberService;
 import moim_today.domain.member.MemberSession;
 import moim_today.dto.member.PasswordRecoverRequest;
 import moim_today.dto.member.PasswordUpdateRequest;
+import moim_today.dto.member.ProfileUpdateRequest;
 import moim_today.fake_DB.FakeMemberSession;
 import moim_today.fake_class.member.FakeMemberService;
 import moim_today.util.ControllerTest;
@@ -18,8 +19,7 @@ import static moim_today.global.constant.MemberSessionConstant.MEMBER_SESSION;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -138,5 +138,32 @@ class MemberControllerTest extends ControllerTest {
                                 )
                                 .build()
                         )));
+    }
+
+    @DisplayName("프로필을 정보를 수정한다.")
+    @Test
+    void updateProfile() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        MemberSession memberSession = FakeMemberSession.createMemberSession();
+        session.setAttribute(MEMBER_SESSION.value(), objectMapper.writeValueAsString(memberSession));
+        ProfileUpdateRequest profileUpdateRequest = new ProfileUpdateRequest(1L);
+        String json = objectMapper.writeValueAsString(profileUpdateRequest);
+
+        mockMvc.perform(patch("/api/members/profile")
+                        .session(session)
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("프로필 정보 수정 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("프로필 정보 수정")
+                                .requestFields(
+                                        fieldWithPath("departmentId").type(NUMBER).description("주 전공 아이디")
+                                )
+                                .build()
+                        )));
+
     }
 }

--- a/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
@@ -8,18 +8,17 @@ import moim_today.dto.member.PasswordUpdateRequest;
 import moim_today.fake_DB.FakeMemberSession;
 import moim_today.fake_class.member.FakeMemberService;
 import moim_today.util.ControllerTest;
-import moim_today.util.TestConstant;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpSession;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static moim_today.global.constant.MemberSessionConstant.*;
+import static moim_today.global.constant.MemberSessionConstant.MEMBER_SESSION;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -107,6 +106,35 @@ class MemberControllerTest extends ControllerTest {
                                 .summary("비밀번호 수정")
                                 .requestFields(
                                         fieldWithPath("newPassword").type(STRING).description("수정 비밀번호")
+                                )
+                                .build()
+                        )));
+    }
+
+    @DisplayName("프로필을 조회에 성공한다.")
+    @Test
+    void getMemberProfile() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        MemberSession memberSession = FakeMemberSession.createMemberSession();
+        session.setAttribute(MEMBER_SESSION.value(), objectMapper.writeValueAsString(memberSession));
+
+        mockMvc.perform(get("/api/members/profile")
+                        .session(session)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("프로필 조회 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("프로필 조회")
+                                .responseFields(
+                                        fieldWithPath("universityName").type(STRING).description("대학명"),
+                                        fieldWithPath("departmentName").type(STRING).description("주 전공"),
+                                        fieldWithPath("email").type(STRING).description("이메일"),
+                                        fieldWithPath("username").type(STRING).description("이름"),
+                                        fieldWithPath("studentId").type(STRING).description("학번"),
+                                        fieldWithPath("birthDate").type(ARRAY).description("생일"),
+                                        fieldWithPath("gender").type(STRING).description("성별"),
+                                        fieldWithPath("memberProfileImageUrl").type(STRING).description("프로필 이미지 url")
                                 )
                                 .build()
                         )));

--- a/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/member/MemberControllerTest.java
@@ -11,16 +11,22 @@ import moim_today.fake_class.member.FakeMemberService;
 import moim_today.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static moim_today.global.constant.MemberSessionConstant.MEMBER_SESSION;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -165,5 +171,28 @@ class MemberControllerTest extends ControllerTest {
                                 .build()
                         )));
 
+    }
+
+    @DisplayName("프로필 이미지를 수정하면 회원의 프로필 이미지 URL 정보가 변경된다.")
+    @Test
+    void updateProfileImage() throws Exception {
+        //given
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "filename.txt",
+                TEXT_PLAIN_VALUE,
+                "content".getBytes());
+
+        //when & then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .multipart(HttpMethod.PATCH, "/api/members/profile-image")
+                        .file(file)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("프로필 이미지 업로드/수정",
+                        requestParts(
+                                partWithName("file").description("프로필 이미지")
+                        )
+                ));
     }
 }

--- a/backend/src/test/java/moim_today/util/ImplementTest.java
+++ b/backend/src/test/java/moim_today/util/ImplementTest.java
@@ -1,7 +1,9 @@
 package moim_today.util;
 
 import moim_today.persistence.repository.certification_token.CertificationTokenRepository;
+import moim_today.persistence.repository.department.DepartmentRepository;
 import moim_today.persistence.repository.member.MemberRepository;
+import moim_today.persistence.repository.university.UniversityRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,6 +20,12 @@ public abstract class ImplementTest {
 
     @Autowired
     protected CertificationTokenRepository certificationTokenRepository;
+
+    @Autowired
+    protected UniversityRepository universityRepository;
+
+    @Autowired
+    protected DepartmentRepository departmentRepository;
 
     @Autowired
     protected PasswordEncoder passwordEncoder;

--- a/backend/src/test/java/moim_today/util/TestConstant.java
+++ b/backend/src/test/java/moim_today/util/TestConstant.java
@@ -1,5 +1,10 @@
 package moim_today.util;
 
+import moim_today.domain.member.enums.Gender;
+import moim_today.persistence.entity.member.MemberJpaEntity;
+
+import java.time.LocalDate;
+
 public enum TestConstant {
 
     EMAIL("email"),
@@ -11,7 +16,20 @@ public enum TestConstant {
 
     CERTIFICATION_TOKEN("certificationToken"),
     NEW_CERTIFICATION_TOKEN("newCertificationToken"),
-    WRONG_CERTIFICATION_TOKEN("wrongCertificationToken");
+    WRONG_CERTIFICATION_TOKEN("wrongCertificationToken"),
+
+    FILE_NAME("file"),
+    ORIGINAL_FILE_NAME("file.txt"),
+    FILE_CONTENT("content"),
+
+    UNIVERSITY_NAME("universityName"),
+    DEPARTMENT_NAME("departmentName"),
+    USERNAME("username"),
+    STUDENT_ID("studentId"),
+    PROFILE_IMAGE_URL("profileImageUrl"),
+
+    STATUS_CODE("200"),
+    MESSAGE("message");
 
     private final String value;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* `[feat]` 회원 프로필 조회 기능 개발
* `[feat]` 회원 프로필 조회 기능 테스트
* `[feat]` 회원 프로필 수정 기능 개발
* `[feat]` 회원 프로필 수정 기능 테스트
* `[feat]` 파일 업로드 폴더명 변경
* `[feat]` 회원 프로필 이미지 수정 기능 개발
* `[feat]` 회원 프로필 이미지 수정 기능 테스트
* `[fix]` 동시 테스트를 고려하여 save후 getId로 ID필드 가져오도록 수정
* `[refactor]` 로그인 요청 API url 수정(auth -> login)
* `[refactor]` FakeInterceptor 세션 주입으로 인한 테스트 세션 추가 로직 삭제
* `[refactor]` 테스트 내 상수 enum으로 변경

## 💬리뷰 요구사항
멤버 프로필 조회 로직에서, 조회 쿼리를 직접 작성하였는데 괜찮은지 한번 봐주시고, 테스트나 예외처리 부분 꼼꼼하게 봐주세용.
그리고 저희 메서드 파라미터의 범위를 어느정도로 잡는게 좋을까요?
예를 들어서 
* memberService.updateProfile(`memberSession.id()`, `profileUpdateRequest`);
* memberService.updateProfile(`memberSession`, `profileUpdateRequest`);

결과적으로 Implement Layer에서는 MemberId만 사용하지만 Controller단에서 넘겨줄 때부터 Id값만을 넘겨주어야 할까요? 아니면 MemberSession으로 넘기다가 Implement Layer에서 풀어서 사용해야 할까요?

제 생각은 사용하지 않는 MemberSession의 필드 값이 많다면 MemberSession을 넘기는 것이 아니라 바로 Id만을 넘기는 것이 좋다고 생각해용

이유는 메서드에서 필요한 파라미터가 더 명확해지고,
사용하지 않는 필드들을 사용해서 실수하는 것을 방지하는 방법이라고 생각합니다.

this closes #35 
