### PR TITLE
[FEAT] 스케줄 조회 및 시간표 중복 예외 처리

### DIFF
--- a/backend/src/main/java/moim_today/application/schedule/ScheduleService.java
+++ b/backend/src/main/java/moim_today/application/schedule/ScheduleService.java
@@ -5,11 +5,14 @@ import moim_today.dto.schedule.ScheduleResponse;
 import moim_today.dto.schedule.ScheduleUpdateRequest;
 import moim_today.dto.schedule.TimeTableRequest;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
 
 public interface ScheduleService {
+
+    List<ScheduleResponse> findAllByWeekly(final long memberId, final LocalDate startDate);
 
     List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth);
 

--- a/backend/src/main/java/moim_today/application/schedule/ScheduleService.java
+++ b/backend/src/main/java/moim_today/application/schedule/ScheduleService.java
@@ -1,11 +1,17 @@
 package moim_today.application.schedule;
 
 import moim_today.dto.schedule.ScheduleCreateRequest;
+import moim_today.dto.schedule.ScheduleResponse;
 import moim_today.dto.schedule.ScheduleUpdateRequest;
 import moim_today.dto.schedule.TimeTableRequest;
 
+import java.time.YearMonth;
+import java.util.List;
+
 
 public interface ScheduleService {
+
+    List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth);
 
     void fetchTimeTable(final long memberId, final TimeTableRequest timeTableRequest);
 

--- a/backend/src/main/java/moim_today/application/schedule/ScheduleServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/schedule/ScheduleServiceImpl.java
@@ -9,6 +9,7 @@ import moim_today.implement.schedule.*;
 import moim_today.persistence.entity.schedule.ScheduleJpaEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -29,6 +30,11 @@ public class ScheduleServiceImpl implements ScheduleService {
         this.scheduleAppender = scheduleAppender;
         this.scheduleUpdater = scheduleUpdater;
         this.scheduleDeleter = scheduleDeleter;
+    }
+
+    @Override
+    public List<ScheduleResponse> findAllByWeekly(final long memberId, final LocalDate startDate) {
+        return scheduleFinder.findAllByWeekly(memberId, startDate);
     }
 
     @Override

--- a/backend/src/main/java/moim_today/application/schedule/ScheduleServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/schedule/ScheduleServiceImpl.java
@@ -2,31 +2,38 @@ package moim_today.application.schedule;
 
 import moim_today.domain.schedule.Schedule;
 import moim_today.dto.schedule.ScheduleCreateRequest;
+import moim_today.dto.schedule.ScheduleResponse;
 import moim_today.dto.schedule.ScheduleUpdateRequest;
 import moim_today.dto.schedule.TimeTableRequest;
-import moim_today.implement.schedule.ScheduleAppender;
-import moim_today.implement.schedule.ScheduleDeleter;
-import moim_today.implement.schedule.ScheduleManager;
-import moim_today.implement.schedule.ScheduleUpdater;
+import moim_today.implement.schedule.*;
 import moim_today.persistence.entity.schedule.ScheduleJpaEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @Service
 public class ScheduleServiceImpl implements ScheduleService {
 
     private final ScheduleManager scheduleManager;
+    private final ScheduleFinder scheduleFinder;
     private final ScheduleAppender scheduleAppender;
     private final ScheduleUpdater scheduleUpdater;
     private final ScheduleDeleter scheduleDeleter;
 
-    public ScheduleServiceImpl(final ScheduleManager scheduleManager, final ScheduleAppender scheduleAppender,
-                               final ScheduleUpdater scheduleUpdater, final ScheduleDeleter scheduleDeleter) {
+    public ScheduleServiceImpl(final ScheduleManager scheduleManager, final ScheduleFinder scheduleFinder,
+                               final ScheduleAppender scheduleAppender, final ScheduleUpdater scheduleUpdater,
+                               final ScheduleDeleter scheduleDeleter) {
         this.scheduleManager = scheduleManager;
+        this.scheduleFinder = scheduleFinder;
         this.scheduleAppender = scheduleAppender;
         this.scheduleUpdater = scheduleUpdater;
         this.scheduleDeleter = scheduleDeleter;
+    }
+
+    @Override
+    public List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth) {
+        return scheduleFinder.findAllByMonthly(memberId, yearMonth);
     }
 
     @Override

--- a/backend/src/main/java/moim_today/domain/schedule/Schedule.java
+++ b/backend/src/main/java/moim_today/domain/schedule/Schedule.java
@@ -38,7 +38,7 @@ public record Schedule(
     }
 
     public boolean isExist(final ScheduleJpaEntity scheduleJpaEntity) {
-        return startDateTime.isAfter(scheduleJpaEntity.getEndDateTime()) &&
-                endDateTime.isBefore(scheduleJpaEntity.getStartDateTime());
+        return scheduleJpaEntity.getEndDateTime().isAfter(startDateTime) &&
+                scheduleJpaEntity.getStartDateTime().isBefore(endDateTime);
     }
 }

--- a/backend/src/main/java/moim_today/domain/schedule/Schedule.java
+++ b/backend/src/main/java/moim_today/domain/schedule/Schedule.java
@@ -36,4 +36,9 @@ public record Schedule(
                 .endDateTime(endDateTime)
                 .build();
     }
+
+    public boolean isExist(final ScheduleJpaEntity scheduleJpaEntity) {
+        return startDateTime.isAfter(scheduleJpaEntity.getEndDateTime()) &&
+                endDateTime.isBefore(scheduleJpaEntity.getStartDateTime());
+    }
 }

--- a/backend/src/main/java/moim_today/domain/schedule/Schedule.java
+++ b/backend/src/main/java/moim_today/domain/schedule/Schedule.java
@@ -37,7 +37,7 @@ public record Schedule(
                 .build();
     }
 
-    public boolean isExist(final ScheduleJpaEntity scheduleJpaEntity) {
+    public boolean exists(final ScheduleJpaEntity scheduleJpaEntity) {
         return scheduleJpaEntity.getEndDateTime().isAfter(startDateTime) &&
                 scheduleJpaEntity.getStartDateTime().isBefore(endDateTime);
     }

--- a/backend/src/main/java/moim_today/dto/schedule/ScheduleResponse.java
+++ b/backend/src/main/java/moim_today/dto/schedule/ScheduleResponse.java
@@ -1,0 +1,22 @@
+package moim_today.dto.schedule;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+@Builder
+public record ScheduleResponse(
+        long scheduleId,
+        long meetingId,
+        String scheduleName,
+        DayOfWeek dayOfWeek,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime
+) {
+
+    @QueryProjection
+    public ScheduleResponse {
+    }
+}

--- a/backend/src/main/java/moim_today/dto/schedule/ScheduleResponse.java
+++ b/backend/src/main/java/moim_today/dto/schedule/ScheduleResponse.java
@@ -1,5 +1,6 @@
 package moim_today.dto.schedule;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 
@@ -12,7 +13,10 @@ public record ScheduleResponse(
         long meetingId,
         String scheduleName,
         DayOfWeek dayOfWeek,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         LocalDateTime startDateTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         LocalDateTime endDateTime
 ) {
 

--- a/backend/src/main/java/moim_today/global/constant/TimeConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/TimeConstant.java
@@ -4,6 +4,7 @@ public enum TimeConstant {
 
     TEN_MINUTES(10),
     ONE_WEEK(1),
+    SIX_DAY(6),
     DAYS_PER_WEEK(7),
     WEEK_START_POINT(1),
 

--- a/backend/src/main/java/moim_today/implement/schedule/ScheduleAppender.java
+++ b/backend/src/main/java/moim_today/implement/schedule/ScheduleAppender.java
@@ -26,7 +26,7 @@ public class ScheduleAppender {
     public void batchUpdateSchedules(final List<Schedule> schedules, final long memberId) {
         List<ScheduleJpaEntity> scheduleJpaEntities = scheduleRepository.findAllByMemberId(memberId);
         for (ScheduleJpaEntity scheduleJpaEntity : scheduleJpaEntities) {
-            schedules.removeIf(schedule -> schedule.isExist(scheduleJpaEntity));
+            schedules.removeIf(schedule -> schedule.exists(scheduleJpaEntity));
         }
 
         TimeTableSchedulingTask timeTableSchedulingTask = TimeTableSchedulingTask.of(schedules, memberId);

--- a/backend/src/main/java/moim_today/implement/schedule/ScheduleAppender.java
+++ b/backend/src/main/java/moim_today/implement/schedule/ScheduleAppender.java
@@ -24,6 +24,11 @@ public class ScheduleAppender {
 
     @Transactional
     public void batchUpdateSchedules(final List<Schedule> schedules, final long memberId) {
+        List<ScheduleJpaEntity> scheduleJpaEntities = scheduleRepository.findAllByMemberId(memberId);
+        for (ScheduleJpaEntity scheduleJpaEntity : scheduleJpaEntities) {
+            schedules.removeIf(schedule -> schedule.isExist(scheduleJpaEntity));
+        }
+
         TimeTableSchedulingTask timeTableSchedulingTask = TimeTableSchedulingTask.of(schedules, memberId);
         scheduleRepository.batchUpdate(timeTableSchedulingTask);
     }

--- a/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
+++ b/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
@@ -26,7 +26,7 @@ public class ScheduleFinder {
         // 시작 날짜의 자정
         LocalDateTime startDateTime = startDate.atStartOfDay();
 
-        // 시작 날짜로부터 7일 후의 자정 전
+        // 시작 날짜로부터 8일 후의 자정 전
         LocalDateTime endDateTime
                 = startDate.plusDays(SIX_DAY.time())
                 .atTime(23, 59, 59, 999999999);

--- a/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
+++ b/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
@@ -1,0 +1,33 @@
+package moim_today.implement.schedule;
+
+import moim_today.dto.schedule.ScheduleResponse;
+import moim_today.global.annotation.Implement;
+import moim_today.persistence.repository.schedule.ScheduleRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+@Implement
+public class ScheduleFinder {
+
+    private final ScheduleRepository scheduleRepository;
+
+    public ScheduleFinder(final ScheduleRepository scheduleRepository) {
+        this.scheduleRepository = scheduleRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth) {
+        // 1일 자정
+        LocalDateTime startDateTime =
+                yearMonth.atDay(1).atStartOfDay();
+
+        // 다음달 1일 자정전
+        LocalDateTime endDateTime =
+                yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999);
+
+        return scheduleRepository.findAllByMonthly(memberId, startDateTime, endDateTime);
+    }
+}

--- a/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
+++ b/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
@@ -26,7 +26,7 @@ public class ScheduleFinder {
         // 시작 날짜의 자정
         LocalDateTime startDateTime = startDate.atStartOfDay();
 
-        // 시작 날짜로부터 8일 후의 자정 전
+        // 시작 날짜로부터 7일 후의 자정 전
         LocalDateTime endDateTime
                 = startDate.plusDays(SIX_DAY.time())
                 .atTime(23, 59, 59, 999999999);

--- a/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
+++ b/backend/src/main/java/moim_today/implement/schedule/ScheduleFinder.java
@@ -5,9 +5,12 @@ import moim_today.global.annotation.Implement;
 import moim_today.persistence.repository.schedule.ScheduleRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+
+import static moim_today.global.constant.TimeConstant.SIX_DAY;
 
 @Implement
 public class ScheduleFinder {
@@ -19,6 +22,20 @@ public class ScheduleFinder {
     }
 
     @Transactional(readOnly = true)
+    public List<ScheduleResponse> findAllByWeekly(final long memberId, final LocalDate startDate) {
+        // 시작 날짜의 자정
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+
+        // 시작 날짜로부터 7일 후의 자정 전
+        LocalDateTime endDateTime
+                = startDate.plusDays(SIX_DAY.time())
+                .atTime(23, 59, 59, 999999999);
+
+        return scheduleRepository.findAllByDateTime(memberId, startDateTime, endDateTime);
+    }
+
+
+    @Transactional(readOnly = true)
     public List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth) {
         // 1일 자정
         LocalDateTime startDateTime =
@@ -28,6 +45,6 @@ public class ScheduleFinder {
         LocalDateTime endDateTime =
                 yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999);
 
-        return scheduleRepository.findAllByMonthly(memberId, startDateTime, endDateTime);
+        return scheduleRepository.findAllByDateTime(memberId, startDateTime, endDateTime);
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleJpaRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleJpaRepository.java
@@ -3,5 +3,9 @@ package moim_today.persistence.repository.schedule;
 import moim_today.persistence.entity.schedule.ScheduleJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ScheduleJpaRepository extends JpaRepository<ScheduleJpaEntity, Long> {
+
+    List<ScheduleJpaEntity> findAllByMemberId(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepository.java
@@ -13,6 +13,8 @@ public interface ScheduleRepository {
 
     ScheduleJpaEntity getById(final long scheduleId);
 
+    List<ScheduleJpaEntity> findAllByMemberId(final long memberId);
+
     List<ScheduleResponse> findAllByMonthly(final long memberId, final LocalDateTime startDateTime, final LocalDateTime endDateTime);
 
     void save(final ScheduleJpaEntity scheduleJpaEntity);

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepository.java
@@ -1,13 +1,19 @@
 package moim_today.persistence.repository.schedule;
 
+import moim_today.dto.schedule.ScheduleResponse;
 import moim_today.dto.schedule.ScheduleUpdateRequest;
 import moim_today.dto.schedule.TimeTableSchedulingTask;
 import moim_today.persistence.entity.schedule.ScheduleJpaEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 
 public interface ScheduleRepository {
 
     ScheduleJpaEntity getById(final long scheduleId);
+
+    List<ScheduleResponse> findAllByMonthly(final long memberId, final LocalDateTime startDateTime, final LocalDateTime endDateTime);
 
     void save(final ScheduleJpaEntity scheduleJpaEntity);
 

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepository.java
@@ -15,7 +15,7 @@ public interface ScheduleRepository {
 
     List<ScheduleJpaEntity> findAllByMemberId(final long memberId);
 
-    List<ScheduleResponse> findAllByMonthly(final long memberId, final LocalDateTime startDateTime, final LocalDateTime endDateTime);
+    List<ScheduleResponse> findAllByDateTime(final long memberId, final LocalDateTime startDateTime, final LocalDateTime endDateTime);
 
     void save(final ScheduleJpaEntity scheduleJpaEntity);
 

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
@@ -2,6 +2,8 @@ package moim_today.persistence.repository.schedule;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import moim_today.domain.schedule.Schedule;
+import moim_today.dto.schedule.QScheduleResponse;
+import moim_today.dto.schedule.ScheduleResponse;
 import moim_today.dto.schedule.ScheduleUpdateRequest;
 import moim_today.dto.schedule.TimeTableSchedulingTask;
 import moim_today.global.error.NotFoundException;
@@ -41,6 +43,29 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
     public ScheduleJpaEntity getById(final long scheduleId) {
         return scheduleJpaRepository.findById(scheduleId)
                 .orElseThrow(() -> new NotFoundException(SCHEDULE_NOT_FOUND.message()));
+    }
+
+    @Override
+    public List<ScheduleResponse> findAllByMonthly(final long memberId, final LocalDateTime startDateTime,
+                                                   final LocalDateTime endDateTime) {
+        return queryFactory.select(
+                        new QScheduleResponse(
+                                scheduleJpaEntity.id,
+                                scheduleJpaEntity.meetingId,
+                                scheduleJpaEntity.scheduleName,
+                                scheduleJpaEntity.dayOfWeek,
+                                scheduleJpaEntity.startDateTime,
+                                scheduleJpaEntity.endDateTime
+                        ))
+                .from(scheduleJpaEntity)
+                .where(
+                        scheduleJpaEntity.memberId.eq(memberId)
+                                .and(scheduleJpaEntity.startDateTime.after(startDateTime))
+                                .and(scheduleJpaEntity.startDateTime.before(endDateTime))
+                                .and(scheduleJpaEntity.endDateTime.after(startDateTime))
+                                .and(scheduleJpaEntity.endDateTime.before(endDateTime))
+                )
+                .fetch();
     }
 
     @Override

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
@@ -60,10 +60,10 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 .from(scheduleJpaEntity)
                 .where(
                         scheduleJpaEntity.memberId.eq(memberId)
-                                .and(scheduleJpaEntity.startDateTime.after(startDateTime))
-                                .and(scheduleJpaEntity.startDateTime.before(endDateTime))
-                                .and(scheduleJpaEntity.endDateTime.after(startDateTime))
-                                .and(scheduleJpaEntity.endDateTime.before(endDateTime))
+                                .and(scheduleJpaEntity.startDateTime.goe(startDateTime))
+                                .and(scheduleJpaEntity.startDateTime.loe(endDateTime))
+                                .and(scheduleJpaEntity.endDateTime.goe(startDateTime))
+                                .and(scheduleJpaEntity.endDateTime.loe(endDateTime))
                 )
                 .fetch();
     }

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
@@ -51,8 +51,8 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
     }
 
     @Override
-    public List<ScheduleResponse> findAllByMonthly(final long memberId, final LocalDateTime startDateTime,
-                                                   final LocalDateTime endDateTime) {
+    public List<ScheduleResponse> findAllByDateTime(final long memberId, final LocalDateTime startDateTime,
+                                                    final LocalDateTime endDateTime) {
         return queryFactory.select(
                         new QScheduleResponse(
                                 scheduleJpaEntity.id,

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/ScheduleRepositoryImpl.java
@@ -46,6 +46,11 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
     }
 
     @Override
+    public List<ScheduleJpaEntity> findAllByMemberId(final long memberId) {
+        return scheduleJpaRepository.findAllByMemberId(memberId);
+    }
+
+    @Override
     public List<ScheduleResponse> findAllByMonthly(final long memberId, final LocalDateTime startDateTime,
                                                    final LocalDateTime endDateTime) {
         return queryFactory.select(

--- a/backend/src/main/java/moim_today/presentation/schedule/ScheduleController.java
+++ b/backend/src/main/java/moim_today/presentation/schedule/ScheduleController.java
@@ -22,14 +22,14 @@ public class ScheduleController {
         this.scheduleService = scheduleService;
     }
 
-    @GetMapping("/schedules-weekly")
+    @GetMapping("/schedules/weekly")
     public CollectionResponse<List<ScheduleResponse>> findAllByWeekly(@Login final MemberSession memberSession,
                                                                       @RequestParam final LocalDate startDate) {
         List<ScheduleResponse> scheduleResponses = scheduleService.findAllByWeekly(memberSession.id(), startDate);
         return CollectionResponse.of(scheduleResponses);
     }
 
-    @GetMapping("/schedules-monthly")
+    @GetMapping("/schedules/monthly")
     public CollectionResponse<List<ScheduleResponse>> findAllByMonthly(@Login final MemberSession memberSession,
                                                                       @RequestParam final YearMonth yearMonth) {
         List<ScheduleResponse> scheduleResponses = scheduleService.findAllByMonthly(memberSession.id(), yearMonth);

--- a/backend/src/main/java/moim_today/presentation/schedule/ScheduleController.java
+++ b/backend/src/main/java/moim_today/presentation/schedule/ScheduleController.java
@@ -7,11 +7,12 @@ import moim_today.global.annotation.Login;
 import moim_today.global.response.CollectionResponse;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
 
-@RequestMapping("/api/schedules")
+@RequestMapping("/api")
 @RestController
 public class ScheduleController {
 
@@ -21,32 +22,39 @@ public class ScheduleController {
         this.scheduleService = scheduleService;
     }
 
-    @GetMapping
+    @GetMapping("/schedules-weekly")
+    public CollectionResponse<List<ScheduleResponse>> findAllByWeekly(@Login final MemberSession memberSession,
+                                                                      @RequestParam final LocalDate startDate) {
+        List<ScheduleResponse> scheduleResponses = scheduleService.findAllByWeekly(memberSession.id(), startDate);
+        return CollectionResponse.of(scheduleResponses);
+    }
+
+    @GetMapping("/schedules-monthly")
     public CollectionResponse<List<ScheduleResponse>> findAllByMonthly(@Login final MemberSession memberSession,
-                                                                       @RequestParam final YearMonth yearMonth) {
+                                                                      @RequestParam final YearMonth yearMonth) {
         List<ScheduleResponse> scheduleResponses = scheduleService.findAllByMonthly(memberSession.id(), yearMonth);
         return CollectionResponse.of(scheduleResponses);
     }
 
-    @PostMapping("/timetable")
+    @PostMapping("/schedules/timetable")
     public void fetchTimeTable(@Login final MemberSession memberSession,
                                @RequestBody final TimeTableRequest timeTableRequest) {
         scheduleService.fetchTimeTable(memberSession.id(), timeTableRequest);
     }
 
-    @PostMapping
+    @PostMapping("/schedules")
     public void createSchedule(@Login final MemberSession memberSession,
                                @RequestBody final ScheduleCreateRequest scheduleCreateRequest) {
         scheduleService.createSchedule(memberSession.id(), scheduleCreateRequest);
     }
 
-    @PatchMapping
+    @PatchMapping("/schedules")
     public void updateSchedule(@Login final MemberSession memberSession,
                                @RequestBody final ScheduleUpdateRequest scheduleUpdateRequest) {
         scheduleService.updateSchedule(memberSession.id(), scheduleUpdateRequest);
     }
 
-    @DeleteMapping
+    @DeleteMapping("/schedules")
     public void deleteSchedule(@Login final MemberSession memberSession,
                                @RequestBody final ScheduleDeleteRequest scheduleDeleteRequest) {
         scheduleService.deleteSchedule(memberSession.id(), scheduleDeleteRequest.scheduleId());

--- a/backend/src/main/java/moim_today/presentation/schedule/ScheduleController.java
+++ b/backend/src/main/java/moim_today/presentation/schedule/ScheduleController.java
@@ -2,12 +2,13 @@ package moim_today.presentation.schedule;
 
 import moim_today.application.schedule.ScheduleService;
 import moim_today.domain.member.MemberSession;
-import moim_today.dto.schedule.ScheduleCreateRequest;
-import moim_today.dto.schedule.ScheduleDeleteRequest;
-import moim_today.dto.schedule.ScheduleUpdateRequest;
-import moim_today.dto.schedule.TimeTableRequest;
+import moim_today.dto.schedule.*;
 import moim_today.global.annotation.Login;
+import moim_today.global.response.CollectionResponse;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
+import java.util.List;
 
 
 @RequestMapping("/api/schedules")
@@ -18,6 +19,13 @@ public class ScheduleController {
 
     public ScheduleController(final ScheduleService scheduleService) {
         this.scheduleService = scheduleService;
+    }
+
+    @GetMapping
+    public CollectionResponse<List<ScheduleResponse>> findAllByMonthly(@Login final MemberSession memberSession,
+                                                                       @RequestParam final YearMonth yearMonth) {
+        List<ScheduleResponse> scheduleResponses = scheduleService.findAllByMonthly(memberSession.id(), yearMonth);
+        return CollectionResponse.of(scheduleResponses);
     }
 
     @PostMapping("/timetable")

--- a/backend/src/test/java/moim_today/domain/schedule/ScheduleTest.java
+++ b/backend/src/test/java/moim_today/domain/schedule/ScheduleTest.java
@@ -1,0 +1,97 @@
+package moim_today.domain.schedule;
+
+import moim_today.persistence.entity.schedule.ScheduleJpaEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+class ScheduleTest {
+
+    @DisplayName("새롭게 등록하는 스케줄 시작시간과 겹치는 스케줄이 있으면 true를 반환한다.")
+    @Test
+    void beforeScheduleAlreadyExist() {
+        // given
+        Schedule schedule = Schedule.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity beforeScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 8, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 1))
+                .build();
+
+        // when
+        boolean exist = schedule.isExist(beforeScheduleJpaEntity);
+
+        // then
+        assertThat(exist).isTrue();
+    }
+
+    @DisplayName("새롭게 등록하는 스케줄 시작시간과 겹치지 않으면 false를 반환한다.")
+    @Test
+    void beforeScheduleNotExist() {
+        // given
+        Schedule schedule = Schedule.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity beforeScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 8, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .build();
+
+        // when
+        boolean exist = schedule.isExist(beforeScheduleJpaEntity);
+
+        // then
+        assertThat(exist).isFalse();
+    }
+
+    @DisplayName("새롭게 등록하는 스케줄 시작시간과 겹치는 스케줄이 있으면 true를 반환한다.")
+    @Test
+    void afterScheduleAlreadyExist() {
+        // given
+        Schedule schedule = Schedule.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity afterScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 11, 59, 59))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 14, 0, 0))
+                .build();
+
+        // when
+        boolean exist = schedule.isExist(afterScheduleJpaEntity);
+
+        // then
+        assertThat(exist).isTrue();
+    }
+
+    @DisplayName("새롭게 등록하는 스케줄 시작시간과 겹치지 않으면 false를 반환한다.")
+    @Test
+    void afterScheduleNotExist() {
+        // given
+        Schedule schedule = Schedule.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity afterScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 14, 0, 0))
+                .build();
+
+        // when
+        boolean exist = schedule.isExist(afterScheduleJpaEntity);
+
+        // then
+        assertThat(exist).isFalse();
+    }
+}

--- a/backend/src/test/java/moim_today/domain/schedule/ScheduleTest.java
+++ b/backend/src/test/java/moim_today/domain/schedule/ScheduleTest.java
@@ -26,7 +26,7 @@ class ScheduleTest {
                 .build();
 
         // when
-        boolean exist = schedule.isExist(beforeScheduleJpaEntity);
+        boolean exist = schedule.exists(beforeScheduleJpaEntity);
 
         // then
         assertThat(exist).isTrue();
@@ -47,7 +47,7 @@ class ScheduleTest {
                 .build();
 
         // when
-        boolean exist = schedule.isExist(beforeScheduleJpaEntity);
+        boolean exist = schedule.exists(beforeScheduleJpaEntity);
 
         // then
         assertThat(exist).isFalse();
@@ -68,7 +68,7 @@ class ScheduleTest {
                 .build();
 
         // when
-        boolean exist = schedule.isExist(afterScheduleJpaEntity);
+        boolean exist = schedule.exists(afterScheduleJpaEntity);
 
         // then
         assertThat(exist).isTrue();
@@ -89,7 +89,7 @@ class ScheduleTest {
                 .build();
 
         // when
-        boolean exist = schedule.isExist(afterScheduleJpaEntity);
+        boolean exist = schedule.exists(afterScheduleJpaEntity);
 
         // then
         assertThat(exist).isFalse();

--- a/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
+++ b/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
@@ -20,7 +20,34 @@ public class FakeScheduleService implements ScheduleService {
 
     @Override
     public List<ScheduleResponse> findAllByWeekly(final long memberId, final LocalDate localDate) {
-        return List.of();
+        ScheduleResponse scheduleResponse1 = ScheduleResponse.builder()
+                .scheduleId(1L)
+                .meetingId(0L)
+                .scheduleName("스케줄명 1")
+                .dayOfWeek(DayOfWeek.MONDAY)
+                .startDateTime(LocalDateTime.of(2024, 03, 04, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 03, 04, 12, 0, 0))
+                .build();
+
+        ScheduleResponse scheduleResponse2 = ScheduleResponse.builder()
+                .scheduleId(2L)
+                .meetingId(0L)
+                .scheduleName("스케줄명 2")
+                .dayOfWeek(DayOfWeek.TUESDAY)
+                .startDateTime(LocalDateTime.of(2024, 03, 05, 12, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 03, 05, 13, 15, 0))
+                .build();
+
+        ScheduleResponse scheduleResponse3 = ScheduleResponse.builder()
+                .scheduleId(3L)
+                .meetingId(1L)
+                .scheduleName("스케줄명 3")
+                .dayOfWeek(DayOfWeek.WEDNESDAY)
+                .startDateTime(LocalDateTime.of(2024, 03, 06, 12, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 03, 06, 13, 15, 0))
+                .build();
+
+        return List.of(scheduleResponse1, scheduleResponse2, scheduleResponse3);
     }
 
     @Override

--- a/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
+++ b/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
@@ -9,9 +9,7 @@ import moim_today.global.error.BadRequestException;
 import moim_today.global.error.ForbiddenException;
 import moim_today.global.error.NotFoundException;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
+import java.time.*;
 import java.util.List;
 
 import static moim_today.global.constant.exception.EveryTimeExceptionConstant.TIME_INPUT_ERROR;
@@ -19,6 +17,11 @@ import static moim_today.global.constant.exception.ScheduleExceptionConstant.*;
 import static moim_today.util.TestConstant.*;
 
 public class FakeScheduleService implements ScheduleService {
+
+    @Override
+    public List<ScheduleResponse> findAllByWeekly(final long memberId, final LocalDate localDate) {
+        return List.of();
+    }
 
     @Override
     public List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth) {

--- a/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
+++ b/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
@@ -9,6 +9,7 @@ import moim_today.global.error.BadRequestException;
 import moim_today.global.error.ForbiddenException;
 import moim_today.global.error.NotFoundException;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -21,7 +22,34 @@ public class FakeScheduleService implements ScheduleService {
 
     @Override
     public List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth) {
-        return List.of();
+        ScheduleResponse scheduleResponse1 = ScheduleResponse.builder()
+                .scheduleId(1L)
+                .meetingId(0L)
+                .scheduleName("스케줄명 1")
+                .dayOfWeek(DayOfWeek.MONDAY)
+                .startDateTime(LocalDateTime.of(2024, 03, 04, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 03, 04, 12, 0, 0))
+                .build();
+
+        ScheduleResponse scheduleResponse2 = ScheduleResponse.builder()
+                .scheduleId(2L)
+                .meetingId(0L)
+                .scheduleName("스케줄명 2")
+                .dayOfWeek(DayOfWeek.TUESDAY)
+                .startDateTime(LocalDateTime.of(2024, 03, 05, 12, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 03, 05, 13, 15, 0))
+                .build();
+
+        ScheduleResponse scheduleResponse3 = ScheduleResponse.builder()
+                .scheduleId(3L)
+                .meetingId(1L)
+                .scheduleName("스케줄명 3")
+                .dayOfWeek(DayOfWeek.WEDNESDAY)
+                .startDateTime(LocalDateTime.of(2024, 03, 06, 12, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 03, 06, 13, 15, 0))
+                .build();
+
+        return List.of(scheduleResponse1, scheduleResponse2, scheduleResponse3);
     }
 
     @Override

--- a/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
+++ b/backend/src/test/java/moim_today/fake_class/schedule/FakeScheduleService.java
@@ -2,6 +2,7 @@ package moim_today.fake_class.schedule;
 
 import moim_today.application.schedule.ScheduleService;
 import moim_today.dto.schedule.ScheduleCreateRequest;
+import moim_today.dto.schedule.ScheduleResponse;
 import moim_today.dto.schedule.ScheduleUpdateRequest;
 import moim_today.dto.schedule.TimeTableRequest;
 import moim_today.global.error.BadRequestException;
@@ -9,12 +10,19 @@ import moim_today.global.error.ForbiddenException;
 import moim_today.global.error.NotFoundException;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
 
 import static moim_today.global.constant.exception.EveryTimeExceptionConstant.TIME_INPUT_ERROR;
 import static moim_today.global.constant.exception.ScheduleExceptionConstant.*;
 import static moim_today.util.TestConstant.*;
 
 public class FakeScheduleService implements ScheduleService {
+
+    @Override
+    public List<ScheduleResponse> findAllByMonthly(final long memberId, final YearMonth yearMonth) {
+        return List.of();
+    }
 
     @Override
     public void fetchTimeTable(final long memberId, final TimeTableRequest timeTableRequest) {

--- a/backend/src/test/java/moim_today/implement/schedule/ScheduleAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/schedule/ScheduleAppenderTest.java
@@ -143,8 +143,8 @@ class ScheduleAppenderTest extends ImplementTest {
                 .build();
 
         ScheduleJpaEntity afterScheduleJpaEntity = ScheduleJpaEntity.builder()
-                .startDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
-                .endDateTime(LocalDateTime.of(2024, 1, 1, 14, 0, 0))
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 14, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 16, 0, 0))
                 .build();
 
         scheduleRepository.save(BeforeScheduleJpaEntity);
@@ -152,8 +152,8 @@ class ScheduleAppenderTest extends ImplementTest {
 
         // given 2
         ScheduleJpaEntity newScheduleJpaEntity = ScheduleJpaEntity.builder()
-                .startDateTime(LocalDateTime.of(2024, 1, 1, 14, 0, 0))
-                .endDateTime(LocalDateTime.of(2024, 1, 1, 16, 0, 0))
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 14, 0, 0))
                 .build();
 
         // then

--- a/backend/src/test/java/moim_today/implement/schedule/ScheduleAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/schedule/ScheduleAppenderTest.java
@@ -35,18 +35,63 @@ class ScheduleAppenderTest extends ImplementTest {
         Schedule schedule2 = Schedule.builder()
                 .scheduleName("스케줄 2")
                 .dayOfWeek(DayOfWeek.THURSDAY)
-                .startDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
-                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .startDateTime(LocalDateTime.of(2024, 1, 2, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 2, 12, 0, 0))
                 .build();
 
         Schedule schedule3 = Schedule.builder()
                 .scheduleName("스케줄 3")
                 .dayOfWeek(DayOfWeek.WEDNESDAY)
+                .startDateTime(LocalDateTime.of(2024, 1, 3, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 3, 12, 0, 0))
+                .build();
+
+        long memberId = 1L;
+
+        // given 2
+        List<Schedule> schedules = List.of(schedule1, schedule2, schedule3);
+
+        // when
+        scheduleAppender.batchUpdateSchedules(schedules, memberId);
+
+        // then
+        assertThat(scheduleRepository.count()).isEqualTo(3);
+    }
+
+    @DisplayName("시간표 정보로 스케줄 정보를 저장할 때 이미 해당 시간에 스케줄이 존재하면 새롭게 저장하지 않는다.")
+    @Test
+    void batchUpdateSchedulesAlreadyExist() {
+        // given 1
+        Schedule schedule1 = Schedule.builder()
+                .scheduleName("스케줄 1")
+                .dayOfWeek(DayOfWeek.MONDAY)
                 .startDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
                 .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
                 .build();
 
+        Schedule schedule2 = Schedule.builder()
+                .scheduleName("스케줄 2")
+                .dayOfWeek(DayOfWeek.THURSDAY)
+                .startDateTime(LocalDateTime.of(2024, 1, 2, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 2, 12, 0, 0))
+                .build();
+
+        Schedule schedule3 = Schedule.builder()
+                .scheduleName("스케줄 3")
+                .dayOfWeek(DayOfWeek.WEDNESDAY)
+                .startDateTime(LocalDateTime.of(2024, 1, 3, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 3, 12, 0, 0))
+                .build();
+
         long memberId = 1L;
+
+        // given 2
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 11, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
 
         // given 2
         List<Schedule> schedules = List.of(schedule1, schedule2, schedule3);

--- a/backend/src/test/java/moim_today/implement/schedule/ScheduleAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/schedule/ScheduleAppenderTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static moim_today.global.constant.exception.ScheduleExceptionConstant.*;
@@ -49,7 +50,10 @@ class ScheduleAppenderTest extends ImplementTest {
         long memberId = 1L;
 
         // given 2
-        List<Schedule> schedules = List.of(schedule1, schedule2, schedule3);
+        List<Schedule> schedules = new ArrayList<>();
+        schedules.add(schedule1);
+        schedules.add(schedule2);
+        schedules.add(schedule3);
 
         // when
         scheduleAppender.batchUpdateSchedules(schedules, memberId);
@@ -62,6 +66,17 @@ class ScheduleAppenderTest extends ImplementTest {
     @Test
     void batchUpdateSchedulesAlreadyExist() {
         // given 1
+        long memberId = 1L;
+
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .startDateTime(LocalDateTime.of(2024, 1, 1, 11, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // given 2
         Schedule schedule1 = Schedule.builder()
                 .scheduleName("스케줄 1")
                 .dayOfWeek(DayOfWeek.MONDAY)
@@ -83,18 +98,11 @@ class ScheduleAppenderTest extends ImplementTest {
                 .endDateTime(LocalDateTime.of(2024, 1, 3, 12, 0, 0))
                 .build();
 
-        long memberId = 1L;
-
-        // given 2
-        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
-                .startDateTime(LocalDateTime.of(2024, 1, 1, 11, 0, 0))
-                .endDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
-                .build();
-
-        scheduleRepository.save(scheduleJpaEntity);
-
-        // given 2
-        List<Schedule> schedules = List.of(schedule1, schedule2, schedule3);
+        // given 3
+        List<Schedule> schedules = new ArrayList<>();
+        schedules.add(schedule1);
+        schedules.add(schedule2);
+        schedules.add(schedule3);
 
         // when
         scheduleAppender.batchUpdateSchedules(schedules, memberId);

--- a/backend/src/test/java/moim_today/implement/schedule/ScheduleFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/schedule/ScheduleFinderTest.java
@@ -1,0 +1,145 @@
+package moim_today.implement.schedule;
+
+import moim_today.dto.schedule.ScheduleResponse;
+import moim_today.persistence.entity.schedule.ScheduleJpaEntity;
+import moim_today.util.ImplementTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ScheduleFinderTest extends ImplementTest {
+
+    @Autowired
+    private ScheduleFinder scheduleFinder;
+
+    @DisplayName("다른 회원의 스케줄은 조회되지 않는다.")
+    @Test
+    void findAllByMonthlyOnlyMember() {
+        // given
+        long memberId = 1L;
+        long otherMemberId = 9999L;
+        YearMonth yearMonth = YearMonth.of(2024, 3);
+
+        ScheduleJpaEntity scheduleJpaEntity1 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 2, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 2, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity2 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
+                .startDateTime(LocalDateTime.of(2024, 3, 3, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 3, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity3 = ScheduleJpaEntity.builder()
+                .memberId(otherMemberId)
+                .scheduleName("스케줄명 3")
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 2, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity1);
+        scheduleRepository.save(scheduleJpaEntity2);
+        scheduleRepository.save(scheduleJpaEntity3);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByMonthly(memberId, yearMonth);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(2);
+    }
+
+    @DisplayName("한 달 스케줄 조회는 당월 1일 자정부터 조회된다.")
+    @Test
+    void findAllByMonthlyStartWithMidNight() {
+        // given
+        long memberId = 1L;
+        YearMonth yearMonth = YearMonth.of(2024, 3);
+
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 1, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 1, 2, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByMonthly(memberId, yearMonth);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(1);
+    }
+
+    @DisplayName("한 달 스케줄 조회는 다음달 1일 자정전까지 조회된다.")
+    @Test
+    void findAllByMonthlyUntilNextMonthMidNight() {
+        // given
+        long memberId = 1L;
+        YearMonth yearMonth = YearMonth.of(2024, 3);
+
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 4, 1, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 4, 1, 2, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByMonthly(memberId, yearMonth);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(0);
+    }
+
+    @DisplayName("캘린더에 나타낼 한 달 스케줄을 조회한다.")
+    @Test
+    void findAllByMonthly() {
+        // given
+        long memberId = 1L;
+        YearMonth yearMonth = YearMonth.of(2024, 3);
+
+        ScheduleJpaEntity scheduleJpaEntity1 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 1, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 1, 2, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity2 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
+                .startDateTime(LocalDateTime.of(2024, 3, 15, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 15, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity3 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 3")
+                .startDateTime(LocalDateTime.of(2024, 3, 31, 23, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 31, 23, 59, 29))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity1);
+        scheduleRepository.save(scheduleJpaEntity2);
+        scheduleRepository.save(scheduleJpaEntity3);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByMonthly(memberId, yearMonth);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(3);
+    }
+}

--- a/backend/src/test/java/moim_today/implement/schedule/ScheduleFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/schedule/ScheduleFinderTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -18,7 +19,147 @@ class ScheduleFinderTest extends ImplementTest {
     @Autowired
     private ScheduleFinder scheduleFinder;
 
-    @DisplayName("다른 회원의 스케줄은 조회되지 않는다.")
+    @DisplayName("다른 회원의 Weekly 스케줄은 조회되지 않는다.")
+    @Test
+    void findAllByWeeklyOnlyMember() {
+        // given
+        long memberId = 1L;
+        long otherMemberId = 9999L;
+        LocalDate startDate = LocalDate.of(2024, 3, 1);
+
+        ScheduleJpaEntity scheduleJpaEntity1 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 2, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 2, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity2 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
+                .startDateTime(LocalDateTime.of(2024, 3, 3, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 3, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity3 = ScheduleJpaEntity.builder()
+                .memberId(otherMemberId)
+                .scheduleName("스케줄명 3")
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 2, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity1);
+        scheduleRepository.save(scheduleJpaEntity2);
+        scheduleRepository.save(scheduleJpaEntity3);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByWeekly(memberId, startDate);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(2);
+    }
+
+    @DisplayName("Weekly 스케줄 조회는 시작 날짜의 자정부터 조회된다.")
+    @Test
+    void findAllByWeeklyStartWithMidNight() {
+        // given
+        long memberId = 1L;
+        LocalDate startDate = LocalDate.of(2024, 3, 1);
+
+        ScheduleJpaEntity beforeScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 2, 29, 22, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 2, 29, 23, 59, 59))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
+                .startDateTime(LocalDateTime.of(2024, 3, 1, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 1, 2, 0, 0))
+                .build();
+
+        scheduleRepository.save(beforeScheduleJpaEntity);
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByWeekly(memberId, startDate);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(1);
+    }
+
+    @DisplayName("Weekly 스케줄 조회는 시작 날짜의 7일 후 자정전까지 조회된다.")
+    @Test
+    void findAllByWeeklyUntilNextMonthMidNight() {
+        // given
+        long memberId = 1L;
+        LocalDate startDate = LocalDate.of(2024, 3, 1);
+
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 6, 22, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 6, 23, 59, 59))
+                .build();
+
+        ScheduleJpaEntity afterScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
+                .startDateTime(LocalDateTime.of(2024, 3, 7, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 7, 2, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByWeekly(memberId, startDate);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(1);
+    }
+
+    @DisplayName("캘린더에 나타낼 Weekly 스케줄을 조회한다.")
+    @Test
+    void findAllByWeekly() {
+        // given
+        long memberId = 1L;
+        LocalDate startDate = LocalDate.of(2024, 3, 1);
+
+        ScheduleJpaEntity scheduleJpaEntity1 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 1, 0, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 1, 2, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity2 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
+                .startDateTime(LocalDateTime.of(2024, 3, 3, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 3, 12, 0, 0))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity3 = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 3")
+                .startDateTime(LocalDateTime.of(2024, 3, 6, 22, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 6, 23, 59, 29))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity1);
+        scheduleRepository.save(scheduleJpaEntity2);
+        scheduleRepository.save(scheduleJpaEntity3);
+
+        // when
+        List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByWeekly(memberId, startDate);
+
+        // then
+        assertThat(scheduleResponses.size()).isEqualTo(3);
+    }
+
+    @DisplayName("다른 회원의 Monthly 스케줄은 조회되지 않는다.")
     @Test
     void findAllByMonthlyOnlyMember() {
         // given
@@ -58,20 +199,28 @@ class ScheduleFinderTest extends ImplementTest {
         assertThat(scheduleResponses.size()).isEqualTo(2);
     }
 
-    @DisplayName("한 달 스케줄 조회는 당월 1일 자정부터 조회된다.")
+    @DisplayName("Monthly 스케줄 조회는 당월 1일 자정부터 조회된다.")
     @Test
     void findAllByMonthlyStartWithMidNight() {
         // given
         long memberId = 1L;
         YearMonth yearMonth = YearMonth.of(2024, 3);
 
-        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+        ScheduleJpaEntity befroeScheduleJpaEntity = ScheduleJpaEntity.builder()
                 .memberId(memberId)
                 .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 2, 29, 22, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 2, 29, 23, 59, 59))
+                .build();
+
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 2")
                 .startDateTime(LocalDateTime.of(2024, 3, 1, 0, 0, 0))
                 .endDateTime(LocalDateTime.of(2024, 3, 1, 2, 0, 0))
                 .build();
 
+        scheduleRepository.save(befroeScheduleJpaEntity);
         scheduleRepository.save(scheduleJpaEntity);
 
         // when
@@ -88,6 +237,13 @@ class ScheduleFinderTest extends ImplementTest {
         long memberId = 1L;
         YearMonth yearMonth = YearMonth.of(2024, 3);
 
+        ScheduleJpaEntity afterScheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberId)
+                .scheduleName("스케줄명 1")
+                .startDateTime(LocalDateTime.of(2024, 3, 31, 22, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 31, 23, 59, 59))
+                .build();
+
         ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
                 .memberId(memberId)
                 .scheduleName("스케줄명 1")
@@ -95,16 +251,18 @@ class ScheduleFinderTest extends ImplementTest {
                 .endDateTime(LocalDateTime.of(2024, 4, 1, 2, 0, 0))
                 .build();
 
+
+        scheduleRepository.save(afterScheduleJpaEntity);
         scheduleRepository.save(scheduleJpaEntity);
 
         // when
         List<ScheduleResponse> scheduleResponses = scheduleFinder.findAllByMonthly(memberId, yearMonth);
 
         // then
-        assertThat(scheduleResponses.size()).isEqualTo(0);
+        assertThat(scheduleResponses.size()).isEqualTo(1);
     }
 
-    @DisplayName("캘린더에 나타낼 한 달 스케줄을 조회한다.")
+    @DisplayName("캘린더에 나타낼 Monthly 스케줄을 조회한다.")
     @Test
     void findAllByMonthly() {
         // given

--- a/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static moim_today.util.TestConstant.*;
 import static moim_today.util.TestConstant.EVERY_TIME_ID;
@@ -34,6 +35,32 @@ class ScheduleControllerTest extends ControllerTest {
     @Override
     protected Object initController() {
         return new ScheduleController(scheduleService);
+    }
+
+    @DisplayName("캘린더에 나타낼 한 달 스케줄을 조회한다.")
+    @Test
+    void findAllByMonthly() throws Exception {
+        mockMvc.perform(get("/api/schedules")
+                        .param("yearMonth", "2024-03")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("캘린더에 나타낼 한 달 스케줄 조회",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("스케줄")
+                                .summary("스케줄 조회")
+                                .queryParameters(
+                                        parameterWithName("yearMonth").description("연도 - 월 정보, ex) 2024-03")
+                                )
+                                .responseFields(
+                                        fieldWithPath("data[0].scheduleId").type(NUMBER).description("스케줄 id"),
+                                        fieldWithPath("data[0].meetingId").type(NUMBER).description("미팅 id"),
+                                        fieldWithPath("data[0].scheduleName").type(STRING).description("스케줄명"),
+                                        fieldWithPath("data[0].dayOfWeek").type(STRING).description("요일"),
+                                        fieldWithPath("data[0].startDateTime").type(STRING).description("시작 시간"),
+                                        fieldWithPath("data[0].endDateTime").type(STRING).description("종료 시간")
+                                )
+                                .build()
+                        )));
     }
 
     @DisplayName("요청 URL로 시간표 정보를 스케줄로 등록한다.")

--- a/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
@@ -40,7 +40,7 @@ class ScheduleControllerTest extends ControllerTest {
     @DisplayName("캘린더에 나타낼 Weekly 스케줄을 조회한다.")
     @Test
     void findAllByWeekly() throws Exception {
-        mockMvc.perform(get("/api/schedules-weekly")
+        mockMvc.perform(get("/api/schedules/weekly")
                         .param("startDate", "2024-03-04")
                 )
                 .andExpect(status().isOk())
@@ -66,7 +66,7 @@ class ScheduleControllerTest extends ControllerTest {
     @DisplayName("캘린더에 나타낼 Monthly 스케줄을 조회한다.")
     @Test
     void findAllByMonthly() throws Exception {
-        mockMvc.perform(get("/api/schedules-monthly")
+        mockMvc.perform(get("/api/schedules/monthly")
                         .param("yearMonth", "2024-03")
                 )
                 .andExpect(status().isOk())

--- a/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
@@ -40,7 +40,7 @@ class ScheduleControllerTest extends ControllerTest {
     @DisplayName("캘린더에 나타낼 한 달 스케줄을 조회한다.")
     @Test
     void findAllByMonthly() throws Exception {
-        mockMvc.perform(get("/api/schedules")
+        mockMvc.perform(get("/api/schedules-monthly")
                         .param("yearMonth", "2024-03")
                 )
                 .andExpect(status().isOk())

--- a/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/schedule/ScheduleControllerTest.java
@@ -37,17 +37,43 @@ class ScheduleControllerTest extends ControllerTest {
         return new ScheduleController(scheduleService);
     }
 
-    @DisplayName("캘린더에 나타낼 한 달 스케줄을 조회한다.")
+    @DisplayName("캘린더에 나타낼 Weekly 스케줄을 조회한다.")
+    @Test
+    void findAllByWeekly() throws Exception {
+        mockMvc.perform(get("/api/schedules-weekly")
+                        .param("startDate", "2024-03-04")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("캘린더에 나타낼 Weekly 스케줄 조회",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("스케줄")
+                                .summary("Weekly 스케줄 조회")
+                                .queryParameters(
+                                        parameterWithName("startDate").description("연도 - 월 - 일 정보, ex) 2024-03-04")
+                                )
+                                .responseFields(
+                                        fieldWithPath("data[0].scheduleId").type(NUMBER).description("스케줄 id"),
+                                        fieldWithPath("data[0].meetingId").type(NUMBER).description("미팅 id"),
+                                        fieldWithPath("data[0].scheduleName").type(STRING).description("스케줄명"),
+                                        fieldWithPath("data[0].dayOfWeek").type(STRING).description("요일"),
+                                        fieldWithPath("data[0].startDateTime").type(STRING).description("시작 시간"),
+                                        fieldWithPath("data[0].endDateTime").type(STRING).description("종료 시간")
+                                )
+                                .build()
+                        )));
+    }
+
+    @DisplayName("캘린더에 나타낼 Monthly 스케줄을 조회한다.")
     @Test
     void findAllByMonthly() throws Exception {
         mockMvc.perform(get("/api/schedules-monthly")
                         .param("yearMonth", "2024-03")
                 )
                 .andExpect(status().isOk())
-                .andDo(document("캘린더에 나타낼 한 달 스케줄 조회",
+                .andDo(document("캘린더에 나타낼 Monthly 스케줄 조회",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("스케줄")
-                                .summary("스케줄 조회")
+                                .summary("Monthly 스케줄 조회")
                                 .queryParameters(
                                         parameterWithName("yearMonth").description("연도 - 월 정보, ex) 2024-03")
                                 )


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61 

## 📝 작업 내용

> 특정 회원의 Monthly 캘린더 스케줄 조회 기능
 특정 회원의 Weekly 캘린더 스케줄 조회 기능
 시간표 등록시 스케줄 중복 예외처리 
 테스트 코드 작성

## 💬 리뷰 요구사항

> 시간과 관련된 체크가 많아서 기능에 비해 테스트 코드가 많습니당.
테스트 코드 위주로 봐주시면 될 것 같습니다

