### PR TITLE
[BE] 대학교 크롤링 리팩토링 및 문서화 작성

### DIFF
--- a/backend/src/main/java/moim_today/application/department/DepartmentService.java
+++ b/backend/src/main/java/moim_today/application/department/DepartmentService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface DepartmentService {
 
-    void putAllDepartment();
+    void patchAllDepartment();
 
     List<DepartmentInfoResponse> getAllDepartment(final long universityId, String universityName);
 }

--- a/backend/src/main/java/moim_today/application/department/DepartmentService.java
+++ b/backend/src/main/java/moim_today/application/department/DepartmentService.java
@@ -8,5 +8,7 @@ public interface DepartmentService {
 
     void patchAllDepartment();
 
-    List<DepartmentInfoResponse> getAllDepartment(final long universityId, String universityName);
+    List<DepartmentInfoResponse> getAllDepartmentByUniversityName(final String universityName);
+
+    List<DepartmentInfoResponse> getAllDepartmentById(final long universityId);
 }

--- a/backend/src/main/java/moim_today/application/department/DepartmentServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/department/DepartmentServiceImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class DepartmentServiceImpl implements DepartmentService{
+public class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentAppender departmentAppender;
     private final DepartmentFinder departmentFinder;
@@ -24,7 +24,12 @@ public class DepartmentServiceImpl implements DepartmentService{
     }
 
     @Override
-    public List<DepartmentInfoResponse> getAllDepartment(final long universityId, final String universityName) {
-        return departmentFinder.getAllDepartment(universityId, universityName);
+    public List<DepartmentInfoResponse> getAllDepartmentByUniversityName(final String universityName) {
+        return departmentFinder.getAllDepartmentByUniversityName(universityName);
+    }
+
+    @Override
+    public List<DepartmentInfoResponse> getAllDepartmentById(final long universityId) {
+        return departmentFinder.getAllDepartmentById(universityId);
     }
 }

--- a/backend/src/main/java/moim_today/application/department/DepartmentServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/department/DepartmentServiceImpl.java
@@ -19,7 +19,7 @@ public class DepartmentServiceImpl implements DepartmentService{
     }
 
     @Override
-    public void putAllDepartment() {
+    public void patchAllDepartment() {
         departmentAppender.putAllDepartment();
     }
 

--- a/backend/src/main/java/moim_today/application/university/UniversityService.java
+++ b/backend/src/main/java/moim_today/application/university/UniversityService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface UniversityService {
 
-    void putAllUniversity();
+    void patchAllUniversity();
 
     List<UniversityInfoResponse> getUniversities();
 }

--- a/backend/src/main/java/moim_today/application/university/UniversityService.java
+++ b/backend/src/main/java/moim_today/application/university/UniversityService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface UniversityService {
 
-    void patchAllUniversity();
+    void fetchAllUniversity();
 
     List<UniversityInfoResponse> getUniversities();
 }

--- a/backend/src/main/java/moim_today/application/university/UniversityServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/university/UniversityServiceImpl.java
@@ -19,7 +19,7 @@ public class UniversityServiceImpl implements UniversityService{
     }
 
     @Override
-    public void patchAllUniversity() {
+    public void fetchAllUniversity() {
         universityUpdater.fetchAllUniversity();
     }
 

--- a/backend/src/main/java/moim_today/application/university/UniversityServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/university/UniversityServiceImpl.java
@@ -19,7 +19,7 @@ public class UniversityServiceImpl implements UniversityService{
     }
 
     @Override
-    public void putAllUniversity() {
+    public void patchAllUniversity() {
         universityUpdater.fetchAllUniversity();
     }
 

--- a/backend/src/main/java/moim_today/application/university/UniversityServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/university/UniversityServiceImpl.java
@@ -1,7 +1,7 @@
 package moim_today.application.university;
 
 import moim_today.dto.university.UniversityInfoResponse;
-import moim_today.implement.university.UniversityAppender;
+import moim_today.implement.university.UniversityUpdater;
 import moim_today.implement.university.UniversityFinder;
 import org.springframework.stereotype.Service;
 
@@ -10,17 +10,17 @@ import java.util.List;
 @Service
 public class UniversityServiceImpl implements UniversityService{
 
-    private final UniversityAppender universityAppender;
+    private final UniversityUpdater universityUpdater;
     private final UniversityFinder universityFinder;
 
-    public UniversityServiceImpl(final UniversityAppender universityAppender, final UniversityFinder universityFinder) {
-        this.universityAppender = universityAppender;
+    public UniversityServiceImpl(final UniversityUpdater universityUpdater, final UniversityFinder universityFinder) {
+        this.universityUpdater = universityUpdater;
         this.universityFinder = universityFinder;
     }
 
     @Override
     public void putAllUniversity() {
-        universityAppender.fetchAllUniversity();
+        universityUpdater.fetchAllUniversity();
     }
 
     @Override

--- a/backend/src/main/java/moim_today/domain/department/Department.java
+++ b/backend/src/main/java/moim_today/domain/department/Department.java
@@ -1,0 +1,38 @@
+package moim_today.domain.department;
+
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
+import moim_today.persistence.entity.university.UniversityJpaEntity;
+
+import java.util.*;
+
+public record Department(
+        long universityId,
+        String departmentName
+) {
+
+    public static List<DepartmentJpaEntity> toEntities(Map<Long, Set<String>> universityAndDepartments) {
+        List<DepartmentJpaEntity> departmentJpaEntities = new ArrayList<>();
+
+        for (Map.Entry<Long, Set<String>> entrySet : universityAndDepartments.entrySet()) {
+            for (String departmentName : entrySet.getValue()) {
+                departmentJpaEntities.add(DepartmentJpaEntity.builder()
+                        .universityId(entrySet.getKey())
+                        .departmentName(departmentName)
+                        .build());
+            }
+        }
+        return departmentJpaEntities;
+    }
+
+    public static Map<Long, Set<String>> convertToUnivIdAndDepartments(final Map<String, Set<String>> universityAndDepartments,
+                                                                       final List<UniversityJpaEntity> universityJpaEntities) {
+        Map<Long, Set<String>> existingUniversities = new HashMap<>();
+
+        universityJpaEntities.stream()
+                .forEach(universityJpaEntity -> {
+                    existingUniversities.put(universityJpaEntity.getId(), universityAndDepartments.get(universityJpaEntity.getUniversityName()));
+                });
+
+        return existingUniversities;
+    }
+}

--- a/backend/src/main/java/moim_today/domain/department/Department.java
+++ b/backend/src/main/java/moim_today/domain/department/Department.java
@@ -10,10 +10,12 @@ public record Department(
         String departmentName
 ) {
 
-    public static List<DepartmentJpaEntity> toEntities(Map<Long, Set<String>> universityAndDepartments) {
+    public static List<DepartmentJpaEntity> toEntities(final Map<String, Set<String>> universityAndDepartments,
+                                                       final List<UniversityJpaEntity> universityJpaEntities) {
+        Map<Long, Set<String>> existingUniversities = convertToUnivIdAndDepartments(universityAndDepartments, universityJpaEntities);
         List<DepartmentJpaEntity> departmentJpaEntities = new ArrayList<>();
 
-        for (Map.Entry<Long, Set<String>> entrySet : universityAndDepartments.entrySet()) {
+        for (Map.Entry<Long, Set<String>> entrySet : existingUniversities.entrySet()) {
             for (String departmentName : entrySet.getValue()) {
                 departmentJpaEntities.add(DepartmentJpaEntity.builder()
                         .universityId(entrySet.getKey())
@@ -24,7 +26,7 @@ public record Department(
         return departmentJpaEntities;
     }
 
-    public static Map<Long, Set<String>> convertToUnivIdAndDepartments(final Map<String, Set<String>> universityAndDepartments,
+    private static Map<Long, Set<String>> convertToUnivIdAndDepartments(final Map<String, Set<String>> universityAndDepartments,
                                                                        final List<UniversityJpaEntity> universityJpaEntities) {
         Map<Long, Set<String>> existingUniversities = new HashMap<>();
 
@@ -35,4 +37,5 @@ public record Department(
 
         return existingUniversities;
     }
+
 }

--- a/backend/src/main/java/moim_today/domain/university/ExtractUniversity.java
+++ b/backend/src/main/java/moim_today/domain/university/ExtractUniversity.java
@@ -64,10 +64,7 @@ public class ExtractUniversity {
 
     public boolean checkUniversityType() {
         List<String> universityType = List.of(ASSOCIATE_DEGREE.value(), GRADUATE_DEGREE.value());
-        if (universityType.contains(this.schoolType)) {
-            return true;
-        }
-        return false;
+        return universityType.contains(this.schoolType);
     }
 
     public UniversityJpaEntity toEntity() {
@@ -75,5 +72,9 @@ public class ExtractUniversity {
                 .universityEmail(this.link)
                 .universityName(this.schoolName)
                 .build();
+    }
+
+    public boolean isEmailEmpty(){
+        return link.isEmpty();
     }
 }

--- a/backend/src/main/java/moim_today/global/config/WebConfig.java
+++ b/backend/src/main/java/moim_today/global/config/WebConfig.java
@@ -28,7 +28,9 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/login",
                         "/api/certification/**",
                         "/api/moims/detail",
-                        "/api/register"
+                        "/api/sign-up",
+                        "/api/universities",
+                        "/api/universities/departments/**"
                 );
     }
 

--- a/backend/src/main/java/moim_today/global/config/WebConfig.java
+++ b/backend/src/main/java/moim_today/global/config/WebConfig.java
@@ -30,7 +30,9 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/moims/detail",
                         "/api/sign-up",
                         "/api/universities",
-                        "/api/universities/departments/**"
+                        "/api/universities/departments/**",
+                        "/api/departments/university-name",
+                        "/api/departments/university-id"
                 );
     }
 

--- a/backend/src/main/java/moim_today/global/constant/DepartmentConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/DepartmentConstant.java
@@ -1,0 +1,19 @@
+package moim_today.global.constant;
+
+public enum DepartmentConstant {
+    DEPARTMENT_UPDATE_BATCH_SIZE("1000");
+
+    private final String value;
+
+    DepartmentConstant(final String value) {
+        this.value = value;
+    }
+
+    public String value(){
+        return value;
+    }
+
+    public int intValue(){
+        return Integer.parseInt(value);
+    }
+}

--- a/backend/src/main/java/moim_today/global/constant/UniversityConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/UniversityConstant.java
@@ -2,6 +2,9 @@ package moim_today.global.constant;
 
 public enum UniversityConstant {
 
+    UNIVERSITY_NAME("university_name"),
+    UNIVERSITY_EMAIL("university_email"),
+
     ASSOCIATE_DEGREE("전문대학"),
     GRADUATE_DEGREE("대학교"),
     DATA_SEARCH("dataSearch"),

--- a/backend/src/main/java/moim_today/global/constant/UniversityConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/UniversityConstant.java
@@ -4,6 +4,7 @@ public enum UniversityConstant {
 
     UNIVERSITY_NAME("university_name"),
     UNIVERSITY_EMAIL("university_email"),
+    UNIVERSITY_ID("university_id"),
 
     ASSOCIATE_DEGREE("전문대학"),
     GRADUATE_DEGREE("대학교"),

--- a/backend/src/main/java/moim_today/implement/department/DepartmentAppender.java
+++ b/backend/src/main/java/moim_today/implement/department/DepartmentAppender.java
@@ -1,53 +1,44 @@
 package moim_today.implement.department;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import moim_today.domain.department.Department;
 import moim_today.global.annotation.Implement;
-import moim_today.global.error.InternalServerException;
 import moim_today.implement.university.UniversityFinder;
 import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import moim_today.persistence.entity.university.UniversityJpaEntity;
 import moim_today.persistence.repository.department.DepartmentRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static moim_today.global.constant.DepartmentConstant.DEPARTMENT_UPDATE_BATCH_SIZE;
-import static moim_today.global.constant.UniversityConstant.*;
-import static moim_today.global.constant.exception.CrawlingExceptionConstant.CRAWLING_PARSE_ERROR;
 
 @Implement
 public class DepartmentAppender {
 
-    private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper;
     private final UniversityFinder universityFinder;
+    private final DepartmentFetcher departmentFetcher;
     private final DepartmentRepository departmentRepository;
 
-    public DepartmentAppender(final RestTemplate restTemplate, final ObjectMapper objectMapper,
-                              final UniversityFinder universityFinder, final DepartmentRepository departmentRepository) {
-        this.restTemplate = restTemplate;
-        this.objectMapper = objectMapper;
+    public DepartmentAppender(final UniversityFinder universityFinder,
+                              final DepartmentFetcher departmentFetcher,
+                              final DepartmentRepository departmentRepository) {
         this.universityFinder = universityFinder;
+        this.departmentFetcher = departmentFetcher;
         this.departmentRepository = departmentRepository;
     }
 
-    @Value("${university.api.key}")
-    private String apiKey;
-
     public void putAllDepartment() {
-        List<String> allMajor = findAllMajor();
+        List<String> allMajor = departmentFetcher.getAllMajor();
         Map<String, Set<String>> departmentUpdateQueue = new HashMap<>();
 
         for (String eachMajor : allMajor) {
-            patchMapAll(departmentUpdateQueue, getDepartments(eachMajor));
+            departmentFetcher.patchDepartmentQueue(departmentUpdateQueue, eachMajor);
             updateDepartmentsIfSizeOver(departmentUpdateQueue, DEPARTMENT_UPDATE_BATCH_SIZE.intValue());
         }
-        batchUpdate(getDepartmentJpaEntities(departmentUpdateQueue));
+        batchUpdate(filterUniversityExistToDepartment(departmentUpdateQueue));
     }
 
     @Transactional
@@ -57,9 +48,15 @@ public class DepartmentAppender {
 
     public void updateDepartmentsIfSizeOver(final Map<String, Set<String>> universityAndDepartments, final int size){
         if(getTotalMapSize(universityAndDepartments) > size){
-            batchUpdate(getDepartmentJpaEntities(universityAndDepartments));
+            batchUpdate(filterUniversityExistToDepartment(universityAndDepartments));
             universityAndDepartments.clear();
         }
+    }
+
+    private List<DepartmentJpaEntity> filterUniversityExistToDepartment(final Map<String, Set<String>> universityAndDepartments) {
+        List<UniversityJpaEntity> universityIdAndDepartments = universityFinder
+                .findUniversitiesByName(universityAndDepartments.keySet().stream().toList());
+        return Department.toEntities(universityAndDepartments, universityIdAndDepartments);
     }
 
     private int getTotalMapSize(final Map<String, Set<String>> mapWithSet){
@@ -68,82 +65,5 @@ public class DepartmentAppender {
             totalSize += entry.getValue().size();
         }
         return totalSize;
-    }
-
-    private List<DepartmentJpaEntity> getDepartmentJpaEntities(final Map<String, Set<String>> universityAndDepartments) {
-        Map<Long, Set<String>> universityIdAndDepartments = filterExistingUniversity(universityAndDepartments);
-        List<DepartmentJpaEntity> departmentJpaEntities = Department.toEntities(universityIdAndDepartments);
-        return departmentJpaEntities;
-    }
-
-    private Map<String, Set<String>> getDepartments(final String eachMajor) {
-        Map<String, Set<String>> universityAndDepartments = getDepartmentsOfUniversity(eachMajor);
-        return universityAndDepartments;
-    }
-
-    private Map<Long, Set<String>> filterExistingUniversity(final Map<String, Set<String>> universityAndDepartments) {
-        List<UniversityJpaEntity> universityJpaEntities = universityFinder
-                .findUniversitiesByName(universityAndDepartments.keySet().stream().toList());
-
-        return Department.convertToUnivIdAndDepartments(universityAndDepartments, universityJpaEntities);
-    }
-
-    private List<String> findAllMajor() {
-        String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_DEPARTMENT_URL.value();
-        String response = restTemplate.getForObject(url, String.class);
-
-        List<String> allMajor = new ArrayList<>();
-        try {
-            JsonNode root = objectMapper.readTree(response);
-            JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
-
-            for (JsonNode item : content) {
-                String majorSeq = item.get(MAJOR_SEQ.value()).asText();
-                allMajor.add(majorSeq);
-            }
-
-            return allMajor;
-        } catch (JsonProcessingException e) {
-            throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
-        }
-    }
-
-    private Map<String, Set<String>> getDepartmentsOfUniversity(final String majorSeq) {
-        String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_UNIVERSITY_BY_DEPARTMENT_URL.value() + majorSeq;
-        String response = restTemplate.getForObject(url, String.class);
-
-        Map<String, Set<String>> universityAndDepartments = new HashMap<>();
-
-        try {
-            JsonNode root = objectMapper.readTree(response);
-            JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
-
-            for (JsonNode item : content) {
-                JsonNode universities = item.path(UNIVERSITY.value());
-                for (JsonNode university : universities) {
-                    String departmentName = university.path(MAJOR_NAME.value()).asText();
-                    String universityName = university.path(SCHOOL_NAME.value()).asText();
-
-                    patchMap(universityAndDepartments, universityName, departmentName);
-                }
-            }
-        } catch (JsonProcessingException e) {
-            throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
-        }
-
-        return universityAndDepartments;
-    }
-
-    private void patchMap(final Map<String, Set<String>> universityAndDepartments, final String universityName, final String departmentName) {
-        Set<String> departments = universityAndDepartments
-                .computeIfAbsent(universityName, k -> new HashSet<>());
-        departments.add(departmentName);
-    }
-
-    private void patchMapAll(final Map<String, Set<String>> baseMap,
-                             final Map<String, Set<String>> addingMap){
-        for (Map.Entry<String, Set<String>> entry : addingMap.entrySet()) {
-            baseMap.computeIfAbsent(entry.getKey(), k -> new HashSet<>()).addAll(entry.getValue());
-        }
     }
 }

--- a/backend/src/main/java/moim_today/implement/department/DepartmentAppender.java
+++ b/backend/src/main/java/moim_today/implement/department/DepartmentAppender.java
@@ -71,6 +71,7 @@ public class DepartmentAppender {
     public List<DepartmentJpaEntity> queryUniversitiesByDepartment(final String majorSeq){
         String url = UNIVERSITY_API_URL.value()+apiKey+FETCH_ALL_UNIVERSITY_BY_DEPARTMENT_URL.value()+majorSeq;
         String response = restTemplate.getForObject(url, String.class);
+
         List<DepartmentJpaEntity> returnDepartmentJpaEntity = new ArrayList<>();
 
         try {
@@ -81,9 +82,9 @@ public class DepartmentAppender {
                 JsonNode universities = item.path(UNIVERSITY.value());
                 for (JsonNode university : universities) {
                     String departmentName = university.path(MAJOR_NAME.value()).asText();
-                    String schoolName = university.path(SCHOOL_NAME.value()).asText();
+                    String universityName = university.path(SCHOOL_NAME.value()).asText();
 
-                    Optional<UniversityJpaEntity> universityJpaEntity = universityFinder.findByName(schoolName);
+                    Optional<UniversityJpaEntity> universityJpaEntity = universityFinder.findByName(universityName);
                     if(universityJpaEntity.isPresent()){
                        saveDepartment(universityJpaEntity.get(), departmentName);
                     }
@@ -94,6 +95,11 @@ public class DepartmentAppender {
         }
 
         return returnDepartmentJpaEntity;
+    }
+
+    @Transactional
+    public List<UniversityJpaEntity> findUniversitiesByName(final List<String> universityName){
+        return universityFinder.findUniversitiesByName(universityName);
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/department/DepartmentAppender.java
+++ b/backend/src/main/java/moim_today/implement/department/DepartmentAppender.java
@@ -43,11 +43,10 @@ public class DepartmentAppender {
     public void putAllDepartment(){
         List<String> allDepartment = fetchAllDepartment();
         for(String eachDepartment : allDepartment){
-            fetchUniversitiesByDepartment(eachDepartment);
+            queryUniversitiesByDepartment(eachDepartment);
         }
     }
 
-    @Transactional
     public List<String> fetchAllDepartment(){
         String url = UNIVERSITY_API_URL.value()+apiKey+FETCH_ALL_DEPARTMENT_URL.value();
         String response = restTemplate.getForObject(url, String.class);
@@ -69,9 +68,10 @@ public class DepartmentAppender {
     }
 
     @Transactional
-    public void fetchUniversitiesByDepartment(final String majorSeq){
+    public List<DepartmentJpaEntity> queryUniversitiesByDepartment(final String majorSeq){
         String url = UNIVERSITY_API_URL.value()+apiKey+FETCH_ALL_UNIVERSITY_BY_DEPARTMENT_URL.value()+majorSeq;
         String response = restTemplate.getForObject(url, String.class);
+        List<DepartmentJpaEntity> returnDepartmentJpaEntity = new ArrayList<>();
 
         try {
             JsonNode root = objectMapper.readTree(response);
@@ -92,6 +92,13 @@ public class DepartmentAppender {
         }catch (JsonProcessingException e){
             throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
         }
+
+        return returnDepartmentJpaEntity;
+    }
+
+    @Transactional
+    public void batchUpdate(List<DepartmentJpaEntity> departmentJpaEntities){
+        departmentRepository.batchUpdate(departmentJpaEntities);
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/department/DepartmentFetcher.java
+++ b/backend/src/main/java/moim_today/implement/department/DepartmentFetcher.java
@@ -1,0 +1,91 @@
+package moim_today.implement.department;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import moim_today.global.annotation.Implement;
+import moim_today.global.error.InternalServerException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+import static moim_today.global.constant.UniversityConstant.*;
+import static moim_today.global.constant.exception.CrawlingExceptionConstant.CRAWLING_PARSE_ERROR;
+
+@Implement
+public class DepartmentFetcher {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public DepartmentFetcher(final RestTemplate restTemplate, final ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Value("${university.api.key}")
+    private String apiKey;
+
+    public List<String> getAllMajor() {
+        String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_DEPARTMENT_URL.value();
+        String response = restTemplate.getForObject(url, String.class);
+        List<String> allMajor = new ArrayList<>();
+        fetchAllMajor(response, allMajor);
+        return allMajor;
+    }
+
+    public void patchDepartmentQueue(final Map<String, Set<String>> baseMap,
+                                     final String majorSeq){
+        Map<String, Set<String>> addingMap = getDepartmentsOfUniversity(majorSeq);
+        for (Map.Entry<String, Set<String>> entry : addingMap.entrySet()) {
+            baseMap.computeIfAbsent(entry.getKey(), k -> new HashSet<>()).addAll(entry.getValue());
+        }
+    }
+
+    private Map<String, Set<String>> getDepartmentsOfUniversity(final String majorSeq) {
+        String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_UNIVERSITY_BY_DEPARTMENT_URL.value() + majorSeq;
+        String response = restTemplate.getForObject(url, String.class);
+        Map<String, Set<String>> universityAndDepartments = new HashMap<>();
+        fetchAllDepartments(response, universityAndDepartments);
+        return universityAndDepartments;
+    }
+
+    private void fetchAllMajor(final String response, final List<String> allMajor) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
+
+            for (JsonNode item : content) {
+                String majorSeq = item.get(MAJOR_SEQ.value()).asText();
+                allMajor.add(majorSeq);
+            }
+        } catch (JsonProcessingException e) {
+            throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
+        }
+    }
+
+    private void fetchAllDepartments(final String response, final Map<String, Set<String>> universityAndDepartments) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
+
+            for (JsonNode item : content) {
+                JsonNode universities = item.path(UNIVERSITY.value());
+                for (JsonNode university : universities) {
+                    String departmentName = university.path(MAJOR_NAME.value()).asText();
+                    String universityName = university.path(SCHOOL_NAME.value()).asText();
+                    patchMap(universityAndDepartments, universityName, departmentName);
+                }
+            }
+        } catch (JsonProcessingException e) {
+            throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
+        }
+    }
+
+    private void patchMap(final Map<String, Set<String>> universityAndDepartments, final String universityName, final String departmentName) {
+        Set<String> departments = universityAndDepartments
+                .computeIfAbsent(universityName, k -> new HashSet<>());
+        departments.add(departmentName);
+    }
+}

--- a/backend/src/main/java/moim_today/implement/department/DepartmentFinder.java
+++ b/backend/src/main/java/moim_today/implement/department/DepartmentFinder.java
@@ -32,22 +32,18 @@ public class DepartmentFinder {
         }
     }
 
-    public List<DepartmentInfoResponse> getAllDepartment(final long universityId, final String universityName){
-        if(universityId != Long.parseLong(NO_UNIVERSITY_ID)){
-            return getAllDepartmentByUniversityId(universityId);
-        }
+    public List<DepartmentInfoResponse> getAllDepartmentByUniversityName(final String universityName){
         if(!universityName.isEmpty()){
-            return getAllDepartmentByUniversityName(universityName);
+            long universityId = universityRepository.getByName(universityName).getId();
+            return departmentRepository.findAllDepartmentOfUniversity(universityId);
         }
         throw new BadRequestException(UNIVERSITY_SEARCH_CONDITIONS_INSUFFICIENT.message());
     }
 
-    private List<DepartmentInfoResponse> getAllDepartmentByUniversityId(final long universityId) {
-        return departmentRepository.findAllDepartmentOfUniversity(universityId);
-    }
-
-    private List<DepartmentInfoResponse> getAllDepartmentByUniversityName(final String universityName) {
-        long universityId = universityRepository.getByName(universityName).getId();
-        return departmentRepository.findAllDepartmentOfUniversity(universityId);
+    public List<DepartmentInfoResponse> getAllDepartmentById(final long universityId){
+        if(universityId != Long.parseLong(NO_UNIVERSITY_ID)){
+            return departmentRepository.findAllDepartmentOfUniversity(universityId);
+        }
+        throw new BadRequestException(UNIVERSITY_SEARCH_CONDITIONS_INSUFFICIENT.message());
     }
 }

--- a/backend/src/main/java/moim_today/implement/university/UniversityAppender.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityAppender.java
@@ -1,54 +1,15 @@
 package moim_today.implement.university;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import moim_today.domain.university.ExtractUniversity;
 import moim_today.global.annotation.Implement;
-import moim_today.global.error.InternalServerException;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
-
-import static moim_today.global.constant.UniversityConstant.*;
-import static moim_today.global.constant.exception.CrawlingExceptionConstant.CRAWLING_PARSE_ERROR;
 
 @Implement
 public class UniversityAppender {
 
-    private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper;
     private final UniversityUpdater universityUpdater;
 
-    @Value("${university.api.key}")
-    private String apiKey;
-
     public UniversityAppender(final RestTemplate restTemplate, final ObjectMapper objectMapper, final UniversityUpdater universityUpdater) {
-        this.restTemplate = restTemplate;
-        this.objectMapper = objectMapper;
         this.universityUpdater = universityUpdater;
-    }
-
-    @Transactional
-    public void fetchAllUniversity(){
-        String url = UNIVERSITY_API_URL.value()+apiKey+FETCH_ALL_UNIVERSITY_URL.value();
-        String response = restTemplate.getForObject(url, String.class);
-
-        try{
-            JsonNode root = objectMapper.readTree(response);
-            JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
-
-            for (JsonNode item : content) {
-                ExtractUniversity extractUniversity = objectMapper.readValue(item.toPrettyString(), ExtractUniversity.class);
-                if(!extractUniversity.checkUniversityType()){
-                    continue;
-                }
-                extractUniversity.extractEmailExtension();
-                universityUpdater.putUniversity(extractUniversity.toEntity());
-            }
-        } catch (JsonProcessingException e){
-            e.printStackTrace();
-            throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
-        }
     }
 }

--- a/backend/src/main/java/moim_today/implement/university/UniversityFinder.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityFinder.java
@@ -51,4 +51,8 @@ public class UniversityFinder {
         Optional<UniversityJpaEntity> findUniversity = universityRepository.findById(universityId);
         return findUniversity.isPresent();
     }
+
+    public List<UniversityJpaEntity> findUniversitiesByName(final List<String> universityNames) {
+        return universityRepository.findExistingUniversities(universityNames);
+    }
 }

--- a/backend/src/main/java/moim_today/implement/university/UniversityFinder.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityFinder.java
@@ -41,7 +41,7 @@ public class UniversityFinder {
 
     @Transactional(readOnly = true)
     public void validateExists(final String emailDomain) {
-        if (!universityRepository.existsByUniversityEmail(emailDomain)) {
+        if (!universityRepository.validateUniversityEmail(emailDomain)) {
             throw new NotFoundException(UNIVERSITY_EMAIL_NOT_FOUND.message());
         }
     }

--- a/backend/src/main/java/moim_today/implement/university/UniversityFinder.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityFinder.java
@@ -52,6 +52,7 @@ public class UniversityFinder {
         return findUniversity.isPresent();
     }
 
+    @Transactional(readOnly = true)
     public List<UniversityJpaEntity> findUniversitiesByName(final List<String> universityNames) {
         return universityRepository.findExistingUniversities(universityNames);
     }

--- a/backend/src/main/java/moim_today/implement/university/UniversityUpdater.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityUpdater.java
@@ -28,7 +28,7 @@ public class UniversityUpdater {
     private String apiKey;
 
     public UniversityUpdater(final UniversityRepository universityRepository,
-                             ObjectMapper objectMapper, RestTemplate restTemplate) {
+                             final ObjectMapper objectMapper, final RestTemplate restTemplate) {
         this.universityRepository = universityRepository;
         this.objectMapper = objectMapper;
         this.restTemplate = restTemplate;

--- a/backend/src/main/java/moim_today/implement/university/UniversityUpdater.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityUpdater.java
@@ -1,19 +1,60 @@
 package moim_today.implement.university;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import moim_today.domain.university.ExtractUniversity;
 import moim_today.global.annotation.Implement;
+import moim_today.global.error.InternalServerException;
 import moim_today.persistence.entity.university.UniversityJpaEntity;
 import moim_today.persistence.repository.university.UniversityRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.Optional;
+
+import static moim_today.global.constant.UniversityConstant.*;
+import static moim_today.global.constant.exception.CrawlingExceptionConstant.CRAWLING_PARSE_ERROR;
 
 @Implement
 public class UniversityUpdater {
 
     private final UniversityRepository universityRepository;
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
 
-    public UniversityUpdater(final UniversityRepository universityRepository) {
+    @Value("${university.api.key}")
+    private String apiKey;
+
+    public UniversityUpdater(final UniversityRepository universityRepository,
+                             ObjectMapper objectMapper, RestTemplate restTemplate) {
         this.universityRepository = universityRepository;
+        this.objectMapper = objectMapper;
+        this.restTemplate = restTemplate;
+    }
+
+    @Transactional
+    public void fetchAllUniversity() {
+        String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_UNIVERSITY_URL.value();
+        String response = restTemplate.getForObject(url, String.class);
+
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
+
+            for (JsonNode item : content) {
+                ExtractUniversity extractUniversity = objectMapper.readValue(item.toPrettyString(), ExtractUniversity.class);
+                if (!extractUniversity.checkUniversityType()) {
+                    continue;
+                }
+                extractUniversity.extractEmailExtension();
+                putUniversity(extractUniversity.toEntity());
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/university/UniversityUpdater.java
+++ b/backend/src/main/java/moim_today/implement/university/UniversityUpdater.java
@@ -49,25 +49,22 @@ public class UniversityUpdater {
                     continue;
                 }
                 extractUniversity.extractEmailExtension();
-                putUniversity(extractUniversity.toEntity());
+                putUniversity(extractUniversity);
             }
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
             throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
         }
     }
 
     @Transactional
-    public void putUniversity(final UniversityJpaEntity universityJpaEntity) {
-        Optional<UniversityJpaEntity> findUniversity = universityRepository.findByName(universityJpaEntity.getUniversityName());
+    public void putUniversity(final ExtractUniversity extractUniversity) {
+        Optional<UniversityJpaEntity> findUniversity = universityRepository.findByName(extractUniversity.getSchoolName());
 
         if (findUniversity.isEmpty()) {
-            universityRepository.save(universityJpaEntity);
-            return;
-        }
-        if (!universityJpaEntity.getUniversityEmail().isEmpty()) {
+            universityRepository.save(extractUniversity.toEntity());
+        } else if (!extractUniversity.isEmailEmpty()) {
             UniversityJpaEntity getUniversity = findUniversity.get();
-            getUniversity.updateEmail(universityJpaEntity.getUniversityEmail());
+            getUniversity.updateEmail(extractUniversity.getLink());
             universityRepository.save(getUniversity);
         }
     }

--- a/backend/src/main/java/moim_today/persistence/entity/department/DepartmentJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/department/DepartmentJpaEntity.java
@@ -28,6 +28,4 @@ public class DepartmentJpaEntity extends BaseTimeEntity {
         this.universityId = universityId;
         this.departmentName = departmentName;
     }
-
-
 }

--- a/backend/src/main/java/moim_today/persistence/entity/department/DepartmentJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/department/DepartmentJpaEntity.java
@@ -28,4 +28,6 @@ public class DepartmentJpaEntity extends BaseTimeEntity {
         this.universityId = universityId;
         this.departmentName = departmentName;
     }
+
+
 }

--- a/backend/src/main/java/moim_today/persistence/entity/university/UniversityJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/university/UniversityJpaEntity.java
@@ -22,7 +22,8 @@ public class UniversityJpaEntity extends BaseTimeEntity {
     }
 
     @Builder
-    public UniversityJpaEntity(final String universityName, final String universityEmail) {
+    public UniversityJpaEntity(long id, final String universityName, final String universityEmail) {
+        this.id = id;
         this.universityName = universityName;
         this.universityEmail = universityEmail;
     }

--- a/backend/src/main/java/moim_today/persistence/entity/university/UniversityJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/university/UniversityJpaEntity.java
@@ -28,7 +28,7 @@ public class UniversityJpaEntity extends BaseTimeEntity {
         this.universityEmail = universityEmail;
     }
 
-    public void updateEmail(String universityEmail){
+    public void updateEmail(final String universityEmail){
         this.universityEmail = universityEmail;
     }
 }

--- a/backend/src/main/java/moim_today/persistence/entity/university/UniversityJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/university/UniversityJpaEntity.java
@@ -22,7 +22,7 @@ public class UniversityJpaEntity extends BaseTimeEntity {
     }
 
     @Builder
-    public UniversityJpaEntity(long id, final String universityName, final String universityEmail) {
+    public UniversityJpaEntity(final long id, final String universityName, final String universityEmail) {
         this.id = id;
         this.universityName = universityName;
         this.universityEmail = universityEmail;

--- a/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepository.java
@@ -12,4 +12,6 @@ public interface DepartmentRepository {
     DepartmentJpaEntity getById(final long departmentId);
 
     List<DepartmentInfoResponse> findAllDepartmentOfUniversity(final long universityId);
+
+    void batchUpdate(List<DepartmentJpaEntity> departmentJpaEntities);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/DepartmentRepositoryImpl.java
@@ -3,8 +3,12 @@ package moim_today.persistence.repository.department;
 import moim_today.dto.department.DepartmentInfoResponse;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.department.DepartmentJpaEntity;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 
 import static moim_today.global.constant.exception.DepartmentExceptionConstant.DEPARTMENT_NOT_FOUND_ERROR;
@@ -13,9 +17,11 @@ import static moim_today.global.constant.exception.DepartmentExceptionConstant.D
 public class DepartmentRepositoryImpl implements DepartmentRepository {
 
     private final DepartmentJpaRepository departmentJpaRepository;
+    private final JdbcTemplate jdbcTemplate;
 
-    public DepartmentRepositoryImpl(final DepartmentJpaRepository departmentJpaRepository) {
+    public DepartmentRepositoryImpl(final DepartmentJpaRepository departmentJpaRepository, JdbcTemplate jdbcTemplate) {
         this.departmentJpaRepository = departmentJpaRepository;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     @Override
@@ -28,6 +34,26 @@ public class DepartmentRepositoryImpl implements DepartmentRepository {
         return departmentJpaRepository.findAllByUniversityId(universityId).stream()
                 .map(DepartmentInfoResponse::from)
                 .toList();
+    }
+
+    @Override
+    public void batchUpdate(final List<DepartmentJpaEntity> departmentJpaEntities) {
+        String sql = "INSERT INTO department (university_id, department_name) VALUES (?, ?)";
+
+        this.jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                DepartmentJpaEntity department = departmentJpaEntities.get(i);
+                ps.setLong(1, department.getUniversityId());
+                ps.setString(2, department.getDepartmentName());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return departmentJpaEntities.size();
+            }
+        });
     }
 
     @Override

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepository.java
@@ -20,4 +20,6 @@ public interface UniversityRepository {
     Optional<UniversityJpaEntity> findById(final long id);
 
     List<UniversityJpaEntity> findAll();
+
+    List<UniversityJpaEntity> findExistingUniversities(List<String> universityNames);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepository.java
@@ -13,7 +13,7 @@ public interface UniversityRepository {
 
     UniversityJpaEntity getByEmail(final String email);
 
-    boolean existsByUniversityEmail(final String universityEmail);
+    boolean validateUniversityEmail(final String universityEmail);
 
     Optional<UniversityJpaEntity> findByName(final String name);
 

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
@@ -11,8 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.util.Collections.nCopies;
-import static moim_today.global.constant.UniversityConstant.UNIVERSITY_EMAIL;
-import static moim_today.global.constant.UniversityConstant.UNIVERSITY_NAME;
+import static moim_today.global.constant.UniversityConstant.*;
 import static moim_today.global.constant.exception.UniversityExceptionConstant.UNIVERSITY_EMAIL_NOT_FOUND;
 import static moim_today.global.constant.exception.UniversityExceptionConstant.UNIVERSITY_NOT_FOUND;
 
@@ -77,11 +76,10 @@ public class UniversityRepositoryImpl implements UniversityRepository {
     }
 
     private RowMapper<UniversityJpaEntity> universityJpaEntityRowMapper() {
-        return (rs, rowNum) -> {
-            return UniversityJpaEntity.builder()
-                    .universityName(rs.getString(UNIVERSITY_NAME.value()))
-                    .universityEmail(rs.getString(UNIVERSITY_EMAIL.value()))
-                    .build();
-        };
+        return (rs, rowNum) -> UniversityJpaEntity.builder()
+                .id(Long.parseLong(rs.getString(UNIVERSITY_ID.value())))
+                .universityName(rs.getString(UNIVERSITY_NAME.value()))
+                .universityEmail(rs.getString(UNIVERSITY_EMAIL.value()))
+                .build();
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
@@ -2,11 +2,17 @@ package moim_today.persistence.repository.university;
 
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.university.UniversityJpaEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Collections.nCopies;
+import static moim_today.global.constant.UniversityConstant.UNIVERSITY_EMAIL;
+import static moim_today.global.constant.UniversityConstant.UNIVERSITY_NAME;
 import static moim_today.global.constant.exception.UniversityExceptionConstant.UNIVERSITY_EMAIL_NOT_FOUND;
 import static moim_today.global.constant.exception.UniversityExceptionConstant.UNIVERSITY_NOT_FOUND;
 
@@ -14,9 +20,11 @@ import static moim_today.global.constant.exception.UniversityExceptionConstant.U
 public class UniversityRepositoryImpl implements UniversityRepository {
 
     private final UniversityJpaRepository universityJpaRepository;
+    private final JdbcTemplate jdbcTemplate;
 
-    public UniversityRepositoryImpl(final UniversityJpaRepository universityJpaRepository) {
+    public UniversityRepositoryImpl(final UniversityJpaRepository universityJpaRepository, JdbcTemplate jdbcTemplate) {
         this.universityJpaRepository = universityJpaRepository;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     @Override
@@ -52,7 +60,28 @@ public class UniversityRepositoryImpl implements UniversityRepository {
     }
 
     @Override
+    public List<UniversityJpaEntity> findExistingUniversities(final List<String> universityNames) {
+        if (universityNames == null || universityNames.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        String inSql = String.join(",", nCopies(universityNames.size(), "?"));
+        String sql = "SELECT * FROM university WHERE "+UNIVERSITY_NAME.value()+" IN (" + inSql + ")";
+
+        return jdbcTemplate.query(sql, universityNames.toArray(new Object[0]), universityJpaEntityRowMapper());
+    }
+
+    @Override
     public Optional<UniversityJpaEntity> findById(final long id) {
         return universityJpaRepository.findById(id);
+    }
+
+    private RowMapper<UniversityJpaEntity> universityJpaEntityRowMapper() {
+        return (rs, rowNum) -> {
+            return UniversityJpaEntity.builder()
+                    .universityName(rs.getString(UNIVERSITY_NAME.value()))
+                    .universityEmail(rs.getString(UNIVERSITY_EMAIL.value()))
+                    .build();
+        };
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/university/UniversityRepositoryImpl.java
@@ -37,7 +37,7 @@ public class UniversityRepositoryImpl implements UniversityRepository {
     }
 
     @Override
-    public boolean existsByUniversityEmail(final String universityEmail) {
+    public boolean validateUniversityEmail(final String universityEmail) {
         return universityJpaRepository.existsByUniversityEmail(universityEmail);
     }
 

--- a/backend/src/main/java/moim_today/presentation/department/DepartmentController.java
+++ b/backend/src/main/java/moim_today/presentation/department/DepartmentController.java
@@ -1,0 +1,39 @@
+package moim_today.presentation.department;
+
+import moim_today.application.department.DepartmentService;
+import moim_today.dto.department.DepartmentInfoResponse;
+import moim_today.global.response.CollectionResponse;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static moim_today.global.constant.StaticSymbolConstant.BLANK;
+import static moim_today.global.constant.StaticSymbolConstant.NO_UNIVERSITY_ID;
+
+@RequestMapping("/api/departments")
+@RestController
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    public DepartmentController(final DepartmentService departmentService) {
+        this.departmentService = departmentService;
+    }
+
+    @PostMapping
+    public void updateDepartmentInfo() {
+        departmentService.patchAllDepartment();
+    }
+
+    @GetMapping("/university-name")
+    public CollectionResponse<List<DepartmentInfoResponse>> getDepartmentsByUniversityName(
+            @RequestParam(defaultValue = BLANK) final String universityName) {
+        return CollectionResponse.of(departmentService.getAllDepartmentByUniversityName(universityName));
+    }
+
+    @GetMapping("/university-id")
+    public CollectionResponse<List<DepartmentInfoResponse>> getDepartmentsByUniversityId(
+            @RequestParam(defaultValue = NO_UNIVERSITY_ID) final long universityId) {
+        return CollectionResponse.of(departmentService.getAllDepartmentById(universityId));
+    }
+}

--- a/backend/src/main/java/moim_today/presentation/university/UniversityController.java
+++ b/backend/src/main/java/moim_today/presentation/university/UniversityController.java
@@ -25,13 +25,13 @@ public class UniversityController {
     }
 
     @PostMapping
-    public void updateCollegeInfo(){
-        universityService.putAllUniversity();
+    public void updateUniversityInfo(){
+        universityService.patchAllUniversity();
     }
 
     @PostMapping("/departments")
     public void updateDepartmentInfo(){
-        departmentService.putAllDepartment();
+        departmentService.patchAllDepartment();
     }
 
     @GetMapping

--- a/backend/src/main/java/moim_today/presentation/university/UniversityController.java
+++ b/backend/src/main/java/moim_today/presentation/university/UniversityController.java
@@ -21,8 +21,8 @@ public class UniversityController {
     }
 
     @PostMapping
-    public void updateUniversityInfo(){
-        universityService.patchAllUniversity();
+    public void fetchUniversityInfo(){
+        universityService.fetchAllUniversity();
     }
 
     @GetMapping

--- a/backend/src/main/java/moim_today/presentation/university/UniversityController.java
+++ b/backend/src/main/java/moim_today/presentation/university/UniversityController.java
@@ -1,27 +1,23 @@
 package moim_today.presentation.university;
 
-import moim_today.application.department.DepartmentService;
 import moim_today.application.university.UniversityService;
-import moim_today.dto.department.DepartmentInfoResponse;
 import moim_today.dto.university.UniversityInfoResponse;
 import moim_today.global.response.CollectionResponse;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-
-import static moim_today.global.constant.StaticSymbolConstant.BLANK;
-import static moim_today.global.constant.StaticSymbolConstant.NO_UNIVERSITY_ID;
 
 @RequestMapping("/api/universities")
 @RestController
 public class UniversityController {
 
     private final UniversityService universityService;
-    private final DepartmentService departmentService;
 
-    public UniversityController(final UniversityService universityService, final DepartmentService departmentService) {
+    public UniversityController(final UniversityService universityService) {
         this.universityService = universityService;
-        this.departmentService = departmentService;
     }
 
     @PostMapping
@@ -29,20 +25,8 @@ public class UniversityController {
         universityService.patchAllUniversity();
     }
 
-    @PostMapping("/departments")
-    public void updateDepartmentInfo(){
-        departmentService.patchAllDepartment();
-    }
-
     @GetMapping
     public CollectionResponse<List<UniversityInfoResponse>> getUniversity(){
         return CollectionResponse.of(universityService.getUniversities());
-    }
-
-    @GetMapping("/departments")
-    public CollectionResponse<List<DepartmentInfoResponse>> getDepartments(
-            @RequestParam(defaultValue = NO_UNIVERSITY_ID, required = false) final long universityId,
-            @RequestParam(defaultValue = BLANK, required = false) final String universityName) {
-        return CollectionResponse.of(departmentService.getAllDepartment(universityId, universityName));
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/department/FakeDepartmentService.java
+++ b/backend/src/test/java/moim_today/fake_class/department/FakeDepartmentService.java
@@ -14,11 +14,26 @@ public class FakeDepartmentService implements DepartmentService {
 
     @Override
     public List<DepartmentInfoResponse> getAllDepartmentByUniversityName(final String universityName) {
-        return null;
+
+        // given
+        List<DepartmentInfoResponse> mockData = List.of(
+                new DepartmentInfoResponse(1L, "소프트웨어학과"),
+                new DepartmentInfoResponse(2L, "의예과"),
+                new DepartmentInfoResponse(3L, "철학과")
+        );
+
+        return mockData;
     }
 
     @Override
     public List<DepartmentInfoResponse> getAllDepartmentById(final long universityId) {
-        return null;
+        // given
+        List<DepartmentInfoResponse> mockData = List.of(
+                new DepartmentInfoResponse(1L, "소프트웨어학과"),
+                new DepartmentInfoResponse(2L, "의예과"),
+                new DepartmentInfoResponse(3L, "철학과")
+        );
+
+        return mockData;
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/department/FakeDepartmentService.java
+++ b/backend/src/test/java/moim_today/fake_class/department/FakeDepartmentService.java
@@ -13,7 +13,12 @@ public class FakeDepartmentService implements DepartmentService {
     }
 
     @Override
-    public List<DepartmentInfoResponse> getAllDepartment(final long universityId, final String universityName) {
+    public List<DepartmentInfoResponse> getAllDepartmentByUniversityName(final String universityName) {
+        return null;
+    }
+
+    @Override
+    public List<DepartmentInfoResponse> getAllDepartmentById(final long universityId) {
         return null;
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/department/FakeDepartmentService.java
+++ b/backend/src/test/java/moim_today/fake_class/department/FakeDepartmentService.java
@@ -1,0 +1,19 @@
+package moim_today.fake_class.department;
+
+import moim_today.application.department.DepartmentService;
+import moim_today.dto.department.DepartmentInfoResponse;
+
+import java.util.List;
+
+public class FakeDepartmentService implements DepartmentService {
+
+    @Override
+    public void patchAllDepartment() {
+
+    }
+
+    @Override
+    public List<DepartmentInfoResponse> getAllDepartment(final long universityId, final String universityName) {
+        return null;
+    }
+}

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -47,4 +47,9 @@ public class FakeMoimService implements MoimService {
     public void updateMoim(final long memberId, final MoimUpdateRequest moimUpdateRequest) {
 
     }
+
+    @Override
+    public MoimMembersResponse findMoimMembers(final long memberId, final long moimId) {
+        return null;
+    }
 }

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -47,9 +47,4 @@ public class FakeMoimService implements MoimService {
     public void updateMoim(final long memberId, final MoimUpdateRequest moimUpdateRequest) {
 
     }
-
-    @Override
-    public MoimMembersResponse findMoimMembers(final long memberId, final long moimId) {
-        return null;
-    }
 }

--- a/backend/src/test/java/moim_today/fake_class/university/FakeUniversityService.java
+++ b/backend/src/test/java/moim_today/fake_class/university/FakeUniversityService.java
@@ -3,6 +3,7 @@ package moim_today.fake_class.university;
 import moim_today.application.university.UniversityService;
 import moim_today.dto.university.UniversityInfoResponse;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class FakeUniversityService implements UniversityService {
@@ -14,6 +15,14 @@ public class FakeUniversityService implements UniversityService {
 
     @Override
     public List<UniversityInfoResponse> getUniversities() {
-        return null;
+
+        // given
+        List<UniversityInfoResponse> mockUniversities = Arrays.asList(
+                new UniversityInfoResponse(1, "가야대학교", "kaya.ac.kr"),
+                new UniversityInfoResponse(2, "가천대학교", "gachon.ac.kr"),
+                new UniversityInfoResponse(3, "가톨릭관동대학교", "cku.ac.kr")
+        );
+
+        return mockUniversities;
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/university/FakeUniversityService.java
+++ b/backend/src/test/java/moim_today/fake_class/university/FakeUniversityService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class FakeUniversityService implements UniversityService {
 
     @Override
-    public void patchAllUniversity() {
+    public void fetchAllUniversity() {
 
     }
 

--- a/backend/src/test/java/moim_today/fake_class/university/FakeUniversityService.java
+++ b/backend/src/test/java/moim_today/fake_class/university/FakeUniversityService.java
@@ -1,0 +1,19 @@
+package moim_today.fake_class.university;
+
+import moim_today.application.university.UniversityService;
+import moim_today.dto.university.UniversityInfoResponse;
+
+import java.util.List;
+
+public class FakeUniversityService implements UniversityService {
+
+    @Override
+    public void patchAllUniversity() {
+
+    }
+
+    @Override
+    public List<UniversityInfoResponse> getUniversities() {
+        return null;
+    }
+}

--- a/backend/src/test/java/moim_today/implement/department/DepartmentAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/department/DepartmentAppenderTest.java
@@ -2,14 +2,16 @@ package moim_today.implement.department;
 
 import moim_today.dto.department.DepartmentInfoResponse;
 import moim_today.persistence.entity.department.DepartmentJpaEntity;
+import moim_today.persistence.entity.university.UniversityJpaEntity;
 import moim_today.util.ImplementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
+import static moim_today.global.constant.DepartmentConstant.DEPARTMENT_UPDATE_BATCH_SIZE;
+import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DepartmentAppenderTest extends ImplementTest {
@@ -19,6 +21,8 @@ class DepartmentAppenderTest extends ImplementTest {
 
     @Autowired
     private DepartmentFinder departmentFinder;
+
+    private final int MAX_SIZE = 1500;
 
     @DisplayName("Department 정보 컬렉션을 한 번에 업데이트한다")
     @Test
@@ -38,5 +42,30 @@ class DepartmentAppenderTest extends ImplementTest {
 
         // then
         assertThat(allDepartment.size()).isEqualTo(10);
+    }
+
+    @DisplayName("Department 정보가 Size 값을 넘을 경우 batchUpdate를 실행한다")
+    @Test
+    void updateDepartmentsIfSizeOver() {
+        // given
+        Map<String, Set<String>> departmentJpaEntities = new HashMap<>();
+        departmentJpaEntities.put(UNIVERSITY_NAME.value(), new HashSet<>());
+        UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
+                .universityName(UNIVERSITY_NAME.value())
+                .universityEmail(AJOU_EMAIL_DOMAIN.value())
+                .build();
+        universityRepository.save(universityJpaEntity);
+
+        for(int i = 0; i < MAX_SIZE; i++){
+            departmentJpaEntities.get(UNIVERSITY_NAME.value()).add(DEPARTMENT_NAME.value()+i);
+        }
+
+        // when
+        departmentAppender.updateDepartmentsIfSizeOver(departmentJpaEntities, DEPARTMENT_UPDATE_BATCH_SIZE.intValue());
+
+        // then
+        long universityId = universityRepository.getByName(UNIVERSITY_NAME.value()).getId();
+        assertThat(departmentRepository.findAllDepartmentOfUniversity(universityId).size())
+                .isEqualTo(MAX_SIZE);
     }
 }

--- a/backend/src/test/java/moim_today/implement/department/DepartmentAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/department/DepartmentAppenderTest.java
@@ -38,7 +38,7 @@ class DepartmentAppenderTest extends ImplementTest {
 
         // when
         departmentAppender.batchUpdate(departmentJpaEntities);
-        List<DepartmentInfoResponse> allDepartment = departmentFinder.getAllDepartment(0, null);
+        List<DepartmentInfoResponse> allDepartment = departmentFinder.getAllDepartmentById(0);
 
         // then
         assertThat(allDepartment.size()).isEqualTo(10);

--- a/backend/src/test/java/moim_today/implement/department/DepartmentAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/department/DepartmentAppenderTest.java
@@ -1,0 +1,42 @@
+package moim_today.implement.department;
+
+import moim_today.dto.department.DepartmentInfoResponse;
+import moim_today.persistence.entity.department.DepartmentJpaEntity;
+import moim_today.util.ImplementTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DepartmentAppenderTest extends ImplementTest {
+
+    @Autowired
+    private DepartmentAppender departmentAppender;
+
+    @Autowired
+    private DepartmentFinder departmentFinder;
+
+    @DisplayName("Department 정보 컬렉션을 한 번에 업데이트한다")
+    @Test
+    void batchUpdate() {
+        // given
+        List<DepartmentJpaEntity> departmentJpaEntities = new ArrayList<>();
+        for(int i = 0; i < 10; i++){
+            departmentJpaEntities.add(DepartmentJpaEntity.builder()
+                            .universityId(0)
+                            .departmentName("departmentName"+i)
+                    .build());
+        }
+
+        // when
+        departmentAppender.batchUpdate(departmentJpaEntities);
+        List<DepartmentInfoResponse> allDepartment = departmentFinder.getAllDepartment(0, null);
+
+        // then
+        assertThat(allDepartment.size()).isEqualTo(10);
+    }
+}

--- a/backend/src/test/java/moim_today/implement/department/DepartmentFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/department/DepartmentFinderTest.java
@@ -1,5 +1,6 @@
 package moim_today.implement.department;
 
+import moim_today.dto.department.DepartmentInfoResponse;
 import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import moim_today.persistence.entity.university.UniversityJpaEntity;
 import moim_today.util.ImplementTest;
@@ -7,7 +8,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class DepartmentFinderTest extends ImplementTest {
 
@@ -41,7 +45,49 @@ class DepartmentFinderTest extends ImplementTest {
 
     }
 
+    @DisplayName("한 대학교의 모든 학과 대학교 이름으로 조회")
     @Test
-    void getAllDepartment() {
+    void getAllDepartmentByUniversityName() {
+        // given
+        UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
+                .universityName(UNIV_NAME)
+                .universityEmail(UNIV_MAIL)
+                .build();
+        UniversityJpaEntity saveUniv = universityRepository.save(universityJpaEntity);
+
+        DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
+                .universityId(saveUniv.getId())
+                .departmentName(DEPARTMENT_NAME)
+                .build();
+        DepartmentJpaEntity saveDepart = departmentRepository.save(departmentJpaEntity);
+
+        // when
+        List<DepartmentInfoResponse> allDepartmentByUniversityName = departmentFinder.getAllDepartmentByUniversityName(UNIV_NAME);
+
+        // then
+        assertThat(allDepartmentByUniversityName.size()).isEqualTo(1);
+    }
+
+    @DisplayName("한 대학교의 모든 학과 대학교 ID로 조회")
+    @Test
+    void getAllDepartmentByUniversityId() {
+        // given
+        UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
+                .universityName(UNIV_NAME)
+                .universityEmail(UNIV_MAIL)
+                .build();
+        UniversityJpaEntity saveUniv = universityRepository.save(universityJpaEntity);
+
+        DepartmentJpaEntity departmentJpaEntity = DepartmentJpaEntity.builder()
+                .universityId(saveUniv.getId())
+                .departmentName(DEPARTMENT_NAME)
+                .build();
+        DepartmentJpaEntity saveDepart = departmentRepository.save(departmentJpaEntity);
+
+        // when
+        List<DepartmentInfoResponse> allDepartmentByUniversityId = departmentFinder.getAllDepartmentById(saveUniv.getId());
+
+        // then
+        assertThat(allDepartmentByUniversityId.size()).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/moim_today/implement/university/UniversityFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/university/UniversityFinderTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,10 +74,13 @@ class UniversityFinderTest extends ImplementTest {
     @Test
     void findUniversitiesByUniversityNames(){
         // given
+        final int MAX_UNIV = 5;
+        final int MAX_TEST_UNIV = 10;
+        Random random = new Random();
         List<String> universityNames = new ArrayList<>();
         String testUniversityName = UNIVERSITY_NAME.value();
 
-        for(int i = 0; i < 10; i++){
+        for(int i = 0; i < MAX_UNIV; i++){
             UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
                     .universityName(testUniversityName+i)
                     .universityEmail(AJOU_EMAIL.value())
@@ -86,7 +90,7 @@ class UniversityFinderTest extends ImplementTest {
             universityNames.add(testUniversityName+i);
         }
 
-        for(int i = 10; i < 20; i++){
+        for(int i = MAX_UNIV; i < MAX_TEST_UNIV; i++){
             universityNames.add(testUniversityName+i);
         }
 
@@ -94,7 +98,14 @@ class UniversityFinderTest extends ImplementTest {
         List<UniversityJpaEntity> findUniversities = universityFinder.findUniversitiesByName(universityNames);
 
         // then
-        assertThat(findUniversities.size()).isEqualTo(10);
+        UniversityJpaEntity randomUniversity = UniversityJpaEntity.builder()
+                .universityName(testUniversityName+(random.nextInt(MAX_UNIV)))
+                .universityEmail(AJOU_EMAIL.value())
+                .build();
+        assertThat(findUniversities.size()).isEqualTo(MAX_UNIV);
+        assertThat(findUniversities.stream().filter(u -> u.getUniversityName().equals(randomUniversity.getUniversityName()))
+                .findAny())
+                .isPresent();
     }
 
     @DisplayName("대학교 ID가 있는지 없는지 검사한다")

--- a/backend/src/test/java/moim_today/implement/university/UniversityFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/university/UniversityFinderTest.java
@@ -11,8 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static moim_today.util.TestConstant.EMAIL;
-import static moim_today.util.TestConstant.UNIVERSITY_NAME;
+import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UniversityFinderTest extends ImplementTest {
@@ -62,17 +61,45 @@ class UniversityFinderTest extends ImplementTest {
 
     @DisplayName("대학교 이름이 없을 때 테스트")
     @Test
-    void 대학교_이름으로_찾았는데_대학교가_없을_때() {
+    void noUniversityFoundByUniversityNameTest() {
         // when
-        Optional<UniversityJpaEntity> findUniversity = universityRepository.findByName(UNIVERSITY_NAME.value());
+        Optional<UniversityJpaEntity> findUniversity = universityFinder.findByName(UNIVERSITY_NAME.value());
 
         // then
         assertThat(findUniversity.isEmpty()).isTrue();
     }
 
+    @DisplayName("대학교 테이블에 존재하는 대학교 이름만 반환한다")
+    @Test
+    void findUniversitiesByUniversityNames(){
+        // given
+        List<String> universityNames = new ArrayList<>();
+        String testUniversityName = UNIVERSITY_NAME.value();
+
+        for(int i = 0; i < 10; i++){
+            UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
+                    .universityName(testUniversityName+i)
+                    .universityEmail(AJOU_EMAIL.value())
+                    .build();
+            universityRepository.save(universityJpaEntity);
+
+            universityNames.add(testUniversityName+i);
+        }
+
+        for(int i = 10; i < 20; i++){
+            universityNames.add(testUniversityName+i);
+        }
+
+        // when
+        List<UniversityJpaEntity> findUniversities = universityFinder.findUniversitiesByName(universityNames);
+
+        // then
+        assertThat(findUniversities.size()).isEqualTo(10);
+    }
+
     @DisplayName("대학교 ID가 있는지 없는지 검사한다")
     @Test
-    void 대학교_ID가_있는지_검사() {
+    void validateUniversityIdTest() {
         // given
         UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
                 .universityName(UNIVERSITY_NAME.value())

--- a/backend/src/test/java/moim_today/persistence/entity/certification_token/PasswordCertificationJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/certification_token/PasswordCertificationJpaEntityTest.java
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static moim_today.util.TestConstant.*;
-import static org.assertj.core.api.Assertions.*;
+import static moim_today.util.TestConstant.CERTIFICATION_TOKEN;
+import static moim_today.util.TestConstant.NEW_CERTIFICATION_TOKEN;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class PasswordCertificationJpaEntityTest {
 

--- a/backend/src/test/java/moim_today/presentation/department/DepartmentControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/department/DepartmentControllerTest.java
@@ -1,0 +1,79 @@
+package moim_today.presentation.department;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import moim_today.fake_class.department.FakeDepartmentService;
+import moim_today.util.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static javax.management.openmbean.SimpleType.STRING;
+import static moim_today.global.constant.StaticSymbolConstant.BLANK;
+import static moim_today.global.constant.StaticSymbolConstant.NO_UNIVERSITY_ID;
+import static moim_today.util.TestConstant.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DepartmentControllerTest extends ControllerTest {
+
+    private final FakeDepartmentService fakeDepartmentService = new FakeDepartmentService();
+
+    @Override
+    protected Object initController() {
+        return new DepartmentController(fakeDepartmentService);
+    }
+
+    @DisplayName("한 대학교의 모든 학과를 대학교 ID로 가져오는 API")
+    @Test
+    void getDepartmentsById() throws Exception {
+        mockMvc.perform(get("/api/departments/university-id")
+                        .param(UNIVERSITY_ID.value(), UNIV_ID.value())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("대학교 ID로 모든 학과 조회 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("학과")
+                                .summary("대학교 ID로 모든 학과 조회")
+                                .requestFields(
+                                        fieldWithPath("universityId").type(STRING).description("대학교 ID")
+                                                .optional().attributes(key("defaultValue").value(NO_UNIVERSITY_ID))
+                                )
+                                .responseFields(
+                                        fieldWithPath("[]").description("대학교 내 모든 학과의 정보 리스트"),
+                                        fieldWithPath("[].departmentId").description("학과 ID"),
+                                        fieldWithPath("[].departmentName").description("학과 이름"),
+                                        fieldWithPath("[].universityId").description("대학교 ID").optional()
+                                )
+                                .build())
+                ));
+    }
+
+    @DisplayName("한 대학교의 모든 학과를 대학교 이름으로 가져오는 API")
+    @Test
+    void getDepartmentsByUniversityName() throws Exception {
+        mockMvc.perform(get("/api/departments/university-name")
+                        .param(UNIVERSITY_NAME.value(), AJOU_UNIVERSITY_NAME.value())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("대학교 이름으로 모든 학과 조회 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("학과")
+                                .summary("대학교 이름으로 모든 학과 조회")
+                                .requestFields(
+                                        fieldWithPath("universityName").type(STRING).description("대학교 이름")
+                                                .optional().attributes(key("defaultValue").value(BLANK))
+                                )
+                                .responseFields(
+                                        fieldWithPath("[]").description("대학교 내 모든 학과의 정보 리스트"),
+                                        fieldWithPath("[].departmentId").description("학과 ID"),
+                                        fieldWithPath("[].departmentName").description("학과 이름"),
+                                        fieldWithPath("[].universityId").description("대학교 ID").optional()
+                                )
+                                .build())
+                ));
+    }
+}

--- a/backend/src/test/java/moim_today/presentation/department/DepartmentControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/department/DepartmentControllerTest.java
@@ -6,14 +6,15 @@ import moim_today.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static javax.management.openmbean.SimpleType.STRING;
 import static moim_today.global.constant.StaticSymbolConstant.BLANK;
 import static moim_today.global.constant.StaticSymbolConstant.NO_UNIVERSITY_ID;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,15 +39,14 @@ class DepartmentControllerTest extends ControllerTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("학과")
                                 .summary("대학교 ID로 모든 학과 조회")
-                                .requestFields(
-                                        fieldWithPath("universityId").type(STRING).description("대학교 ID")
+                                .queryParameters(
+                                        parameterWithName("universityId").description("대학교 ID")
                                                 .optional().attributes(key("defaultValue").value(NO_UNIVERSITY_ID))
                                 )
                                 .responseFields(
-                                        fieldWithPath("[]").description("대학교 내 모든 학과의 정보 리스트"),
-                                        fieldWithPath("[].departmentId").description("학과 ID"),
-                                        fieldWithPath("[].departmentName").description("학과 이름"),
-                                        fieldWithPath("[].universityId").description("대학교 ID").optional()
+                                        fieldWithPath("data").type(ARRAY).description("대학교 내 모든 학과의 정보 리스트"),
+                                        fieldWithPath("data[].departmentId").type(NUMBER).description("학과 ID"),
+                                        fieldWithPath("data[].departmentName").type(STRING).description("학과 이름")
                                 )
                                 .build())
                 ));
@@ -63,15 +63,14 @@ class DepartmentControllerTest extends ControllerTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("학과")
                                 .summary("대학교 이름으로 모든 학과 조회")
-                                .requestFields(
-                                        fieldWithPath("universityName").type(STRING).description("대학교 이름")
+                                .queryParameters(
+                                        parameterWithName("universityName").description("대학교 이름")
                                                 .optional().attributes(key("defaultValue").value(BLANK))
                                 )
                                 .responseFields(
-                                        fieldWithPath("[]").description("대학교 내 모든 학과의 정보 리스트"),
-                                        fieldWithPath("[].departmentId").description("학과 ID"),
-                                        fieldWithPath("[].departmentName").description("학과 이름"),
-                                        fieldWithPath("[].universityId").description("대학교 ID").optional()
+                                        fieldWithPath("data").type(ARRAY).description("대학교 내 모든 학과의 정보 리스트"),
+                                        fieldWithPath("data[].departmentId").type(NUMBER).description("학과 ID"),
+                                        fieldWithPath("data[].departmentName").type(STRING).description("학과 이름")
                                 )
                                 .build())
                 ));

--- a/backend/src/test/java/moim_today/presentation/university/UniversityControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/university/UniversityControllerTest.java
@@ -5,22 +5,23 @@ import moim_today.fake_class.university.FakeUniversityService;
 import moim_today.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class UniversityControllerTest extends ControllerTest {
 
-    private final FakeUniversityService fakeScheduleService = new FakeUniversityService();
+    private final FakeUniversityService fakeUniversityService = new FakeUniversityService();
 
     @Override
     protected Object initController() {
-        return new UniversityController(fakeScheduleService);
+        return new UniversityController(fakeUniversityService);
     }
 
     @DisplayName("모든 대학교 정보를 가져오는 API")
@@ -31,15 +32,19 @@ class UniversityControllerTest extends ControllerTest {
                         .contentType(APPLICATION_JSON)
                 )
                 .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print())
                 .andDo(document("모든 대학교 정보 조회 성공",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("대학교")
                                 .summary("모든 대학교 정보 조회")
                                 .responseFields(
-                                        fieldWithPath("[]").type(STRING).description("대학교 정보 리스트"),
-                                        fieldWithPath("[].universityId").type(STRING).description("대학교 ID"),
-                                        fieldWithPath("[].universityName").type(STRING).description("대학교 이름"),
-                                        fieldWithPath("[].universityEmail").type(STRING).description("대학교 이메일 도메인")
+                                        fieldWithPath("data").type(ARRAY).description("대학교 정보 리스트"),
+                                        fieldWithPath("data[].universityId").type(NUMBER)
+                                                .description("대학교 ID"),
+                                        fieldWithPath("data[].universityName").type(STRING)
+                                                .description("대학교 이름"),
+                                        fieldWithPath("data[].universityEmail").type(STRING)
+                                                .description("대학교 이메일 도메인")
                                 )
                                 .build()
                         )));

--- a/backend/src/test/java/moim_today/presentation/university/UniversityControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/university/UniversityControllerTest.java
@@ -1,0 +1,20 @@
+package moim_today.presentation.university;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UniversityControllerTest {
+
+    @DisplayName("모든 대학교 정보를 가져오는 API")
+    @Test
+    void getUniversity() {
+    }
+
+    @DisplayName("한 대학교의 모든 학과를 가져오는 API")
+    @Test
+    void getDepartments() {
+    }
+
+}

--- a/backend/src/test/java/moim_today/presentation/university/UniversityControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/university/UniversityControllerTest.java
@@ -1,20 +1,47 @@
 package moim_today.presentation.university;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import moim_today.fake_class.university.FakeUniversityService;
+import moim_today.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class UniversityControllerTest {
+class UniversityControllerTest extends ControllerTest {
+
+    private final FakeUniversityService fakeScheduleService = new FakeUniversityService();
+
+    @Override
+    protected Object initController() {
+        return new UniversityController(fakeScheduleService);
+    }
 
     @DisplayName("모든 대학교 정보를 가져오는 API")
     @Test
-    void getUniversity() {
-    }
+    void getUniversity() throws Exception{
 
-    @DisplayName("한 대학교의 모든 학과를 가져오는 API")
-    @Test
-    void getDepartments() {
+        mockMvc.perform(get("/api/universities")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("모든 대학교 정보 조회 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("대학교")
+                                .summary("모든 대학교 정보 조회")
+                                .responseFields(
+                                        fieldWithPath("[]").type(STRING).description("대학교 정보 리스트"),
+                                        fieldWithPath("[].universityId").type(STRING).description("대학교 ID"),
+                                        fieldWithPath("[].universityName").type(STRING).description("대학교 이름"),
+                                        fieldWithPath("[].universityEmail").type(STRING).description("대학교 이메일 도메인")
+                                )
+                                .build()
+                        )));
     }
-
 }

--- a/backend/src/test/java/moim_today/util/TestConstant.java
+++ b/backend/src/test/java/moim_today/util/TestConstant.java
@@ -31,8 +31,10 @@ public enum TestConstant {
 
 
     // 대학교
+    UNIVERSITY_ID("universityID"),
     UNIV_ID("194"),
     UNIVERSITY_NAME("universityName"),
+    AJOU_UNIVERSITY_NAME("아주대학교"),
 
     // 학과
     DEPARTMENT_ID("9369"),

--- a/backend/src/test/java/moim_today/util/TestConstant.java
+++ b/backend/src/test/java/moim_today/util/TestConstant.java
@@ -31,7 +31,7 @@ public enum TestConstant {
 
 
     // 대학교
-    UNIVERSITY_ID("universityID"),
+    UNIVERSITY_ID("universityId"),
     UNIV_ID("194"),
     UNIVERSITY_NAME("universityName"),
     AJOU_UNIVERSITY_NAME("아주대학교"),

--- a/backend/src/test/java/moim_today/util/TestConstant.java
+++ b/backend/src/test/java/moim_today/util/TestConstant.java
@@ -74,4 +74,8 @@ public enum TestConstant {
     public String value() {
         return value;
     }
+
+    public int intValue(){
+        return Integer.parseInt(value);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #71 

## 📝작업 내용

>대학교 크롤링 하는 작업이 외부 API를 이용하기 때문에, 정보를 받아서 쌓아놓고 batch update 하는 방법으로 수정한 것과, 컬렌션 조회를 기존에는 하나씩 select 했던 부분을 in 절을 활용한 select로 개선했습니다.

기존 8분 30초 걸리던 모든 학과 업데이트를 6분 50초까지 줄였습니다.

또한 대학교 문서화를 위한 Controller 테스트에서 CollectionResponse 를 위한 반환값을 문서화도 진행했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

더 좋은 구조로 명확하도록 바꾼 것 같습니다만, 바꾼 후 구조가 더 좋은지는 고민됩니다. 또한 최적화 하는 부분에서 batch 와  컬렌션 조회로 쿼리 횟수는 획기적으로 줄였지만, API 호출 횟수는 외부 API 기준이기 때문에 변함이 없었고, 이 부분이 시간을 많이 소요하는 것 같습니다.
그래서 다음 리팩토링에서는 API 호출을 멀티 쓰레드로 호출해서 각자 DB에 업데이트하도록 수정할 생각인데, 이는 테스트 결과 유의미한 개선이 있는지 보고 PR 날려보겠습니다

