### PR TITLE
[BE] feat : RestTemplate CORS 설정 추가

### DIFF
--- a/backend/src/main/java/moim_today/global/config/CorsInterceptor.java
+++ b/backend/src/main/java/moim_today/global/config/CorsInterceptor.java
@@ -1,0 +1,24 @@
+package moim_today.global.config;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CorsInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        HttpHeaders headers = request.getHeaders();
+        headers.add("Access-Control-Allow-Origin", "*");
+        headers.add("Access-Control-Allow-Methods", "*");
+        headers.add("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+        return execution.execute(request, body);
+    }
+}

--- a/backend/src/main/java/moim_today/global/config/RestTemplateConfig.java
+++ b/backend/src/main/java/moim_today/global/config/RestTemplateConfig.java
@@ -7,8 +7,16 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
 
+    private final CorsInterceptor corsInterceptor;
+
+    public RestTemplateConfig(final CorsInterceptor corsInterceptor) {
+        this.corsInterceptor = corsInterceptor;
+    }
+
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add(corsInterceptor);
+        return restTemplate;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #94 

## 📝작업 내용

> 프론트 서버에서 백엔드 서버로의 요청 모두 CORS 설정을 해놨었는데
백엔드 서버에서 외부 API 요청을 하고 받아온 것에 대한 것은 막혀있어서
RestTemplate 설정을 추가하였습니다.