### PR TITLE
[BE] 파일 기능 문서화

### DIFF
--- a/backend/src/main/java/moim_today/presentation/file/FileController.java
+++ b/backend/src/main/java/moim_today/presentation/file/FileController.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import static moim_today.global.constant.FileTypeConstant.PROFILE_IMAGE;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/files")
 public class FileController {
 
     private final FileService fileService;
@@ -20,13 +20,13 @@ public class FileController {
         this.fileService = fileService;
     }
 
-    @PostMapping(value = "/files")
+    @PostMapping
     public FileInfoResponse uploadFile(@Login final MemberSession memberSession,
-                                       @RequestPart final MultipartFile file) {
+                                       @RequestParam final MultipartFile file) {
         return fileService.uploadFile(PROFILE_IMAGE.value(), file);
     }
 
-    @DeleteMapping("/files")
+    @DeleteMapping
     public void deleteFile(@Login final MemberSession memberSession,
                            @RequestBody final FileDeleteRequest fileDeleteRequest){
         fileService.deleteFile(memberSession, fileDeleteRequest);

--- a/backend/src/test/java/moim_today/fake_class/file/FakeFileService.java
+++ b/backend/src/test/java/moim_today/fake_class/file/FakeFileService.java
@@ -10,7 +10,7 @@ public class FakeFileService implements FileService {
 
     @Override
     public FileInfoResponse uploadFile(final String fileType, final MultipartFile multipartFile) {
-        return new FileInfoResponse("testUploadFileUrl");
+        return new FileInfoResponse("fileUrl");
     }
 
     @Override

--- a/backend/src/test/java/moim_today/presentation/file/FileControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/file/FileControllerTest.java
@@ -1,19 +1,24 @@
 package moim_today.presentation.file;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import moim_today.application.file.FileService;
 import moim_today.dto.file.FileDeleteRequest;
 import moim_today.fake_class.file.FakeFileService;
 import moim_today.util.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.restdocs.headers.HeaderDocumentation;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,25 +36,36 @@ class FileControllerTest extends ControllerTest {
     @Test
     void uploadFileTest() throws Exception {
 
-        MockMultipartFile file1 = new MockMultipartFile(
+        MockMultipartFile file = new MockMultipartFile(
                 FILE_NAME.value(),
                 ORIGINAL_FILE_NAME.value(),
-                MediaType.TEXT_PLAIN_VALUE,
+                MediaType.MULTIPART_FORM_DATA_VALUE,
                 FILE_CONTENT.value().getBytes()
         );
 
-        mockMvc.perform(MockMvcRequestBuilders
-                        .multipart(HttpMethod.POST, "/api/files")
-                        .file(file1)
+        mockMvc.perform(multipart("/api/files")
+                        .file(file)
                 )
                 .andExpect(status().isOk())
-                // ToDo: resdocs + oas3 를 이용한 멀티파트 문서화
                 .andDo(document("파일 업로드",
                         requestParts(
-                                partWithName("file").description("업로드할 파일")
-                        )
-                ));
+                                partWithName("file").description("모임 사진 파일")
+                        ),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("파일")
+                                .summary("파일 업로드")
+                                .requestHeaders(
+                                        HeaderDocumentation.headerWithName(HttpHeaders.CONTENT_TYPE)
+                                                .description(MediaType.MULTIPART_FORM_DATA_VALUE)
+                                )
+                                .responseFields(
+                                        fieldWithPath("uploadFileUrl").type(STRING).description("업로드 한 파일 열람할 url")
+                                )
+                                .build()
+                        )));
     }
+
+//    프론트 사용 불가 , 이용하려면 파일 url 로 정보 매핑할 수 있도록 테이블 추가 필요
 
     @DisplayName("S3 파일을 삭제한다.")
     @Test
@@ -60,7 +76,17 @@ class FileControllerTest extends ControllerTest {
         mockMvc.perform(delete("/api/files")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(fileDeleteRequest)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andDo(document("파일 삭제 (프론트 사용 아직 불가, 요청 정보 얻을 수 있는 기능 부족)",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("파일")
+                                .summary("파일 삭제")
+                                .requestFields(
+                                        fieldWithPath("uploadFilePath").type(STRING).description("파일 업로드 경로"),
+                                        fieldWithPath("fileName").type(STRING).description("파일 이름")
+                                )
+                                .build())
+                ));
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #65 

## 📝작업 내용

> 파일 기능 문서화


## 💬리뷰 요구사항(선택)

> 파일 삭제하는 기능이 프론트가 사용하려면 업로드 파일 URL 을 매핑해서 업로드한 파일 경로, 업로드한 파일 이름을 알아내야 합니다. 그래서 이 기능을 프론트에서 이용하려면 테이블 하나 추가가 필요하다고 생각하는데, 어떻게 생각하시나요? 

closes #65 
