### PR TITLE
[FEAT] 모임 조회시 조회수 증가

### DIFF
--- a/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
@@ -1,5 +1,10 @@
 package moim_today.application.moim.moim;
 
+import jakarta.servlet.http.HttpServletResponse;
+import moim_today.dto.moim.moim.MoimCreateRequest;
+import moim_today.dto.moim.moim.MoimDetailResponse;
+import moim_today.dto.moim.moim.MoimUpdateRequest;
+import moim_today.dto.moim.moim.MoimImageResponse;
 import moim_today.dto.moim.moim.*;
 import moim_today.dto.moim.moim.MoimFilterRequest;
 import org.springframework.web.multipart.MultipartFile;

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
@@ -1,12 +1,7 @@
 package moim_today.application.moim.moim;
 
 import jakarta.servlet.http.HttpServletResponse;
-import moim_today.dto.moim.moim.MoimCreateRequest;
-import moim_today.dto.moim.moim.MoimDetailResponse;
-import moim_today.dto.moim.moim.MoimUpdateRequest;
-import moim_today.dto.moim.moim.MoimImageResponse;
 import moim_today.dto.moim.moim.*;
-import moim_today.dto.moim.moim.MoimFilterRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -18,7 +13,7 @@ public interface MoimService {
 
     MoimImageResponse uploadMoimImage(final MultipartFile file);
 
-    MoimDetailResponse getMoimDetail(final long moimId);
+    MoimDetailResponse getMoimDetail(final long moimId, final String viewedMoimsCookieByUrlEncoded, final HttpServletResponse response);
 
     void updateMoim(final long memberId, final MoimUpdateRequest moimUpdateRequest);
 

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -1,5 +1,6 @@
 package moim_today.application.moim.moim;
 
+import jakarta.servlet.http.HttpServletResponse;
 import moim_today.dto.moim.moim.*;
 import moim_today.dto.moim.moim.MoimFilterRequest;
 import moim_today.implement.file.FileUploader;
@@ -79,9 +80,13 @@ public class MoimServiceImpl implements MoimService{
         return MoimImageResponse.from(imageUrl);
     }
 
+    @Transactional
     @Override
-    public MoimDetailResponse getMoimDetail(final long moimId) {
+    public MoimDetailResponse getMoimDetail(final long moimId,
+                                            final String viewedMoimsCookieByUrlEncoded,
+                                            final HttpServletResponse response) {
         MoimJpaEntity moimJpaEntity =  moimFinder.getById(moimId);
+        moimUpdater.updateMoimViews(moimJpaEntity, viewedMoimsCookieByUrlEncoded, response);
         return MoimDetailResponse.from(moimJpaEntity);
     }
 

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -80,13 +80,12 @@ public class MoimServiceImpl implements MoimService{
         return MoimImageResponse.from(imageUrl);
     }
 
-    @Transactional
     @Override
     public MoimDetailResponse getMoimDetail(final long moimId,
                                             final String viewedMoimsCookieByUrlEncoded,
                                             final HttpServletResponse response) {
         MoimJpaEntity moimJpaEntity =  moimFinder.getById(moimId);
-        moimUpdater.updateMoimViews(moimJpaEntity, viewedMoimsCookieByUrlEncoded, response);
+        moimUpdater.updateMoimViews(moimId, viewedMoimsCookieByUrlEncoded, response);
         return MoimDetailResponse.from(moimJpaEntity);
     }
 

--- a/backend/src/main/java/moim_today/domain/moim/ViewedMoim.java
+++ b/backend/src/main/java/moim_today/domain/moim/ViewedMoim.java
@@ -1,5 +1,6 @@
 package moim_today.domain.moim;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ public record ViewedMoim(
                 .build();
     }
 
+    @JsonIgnore
     public boolean isExpired() {
         return expiredTime.isBefore(LocalDateTime.now());
     }

--- a/backend/src/main/java/moim_today/domain/moim/ViewedMoim.java
+++ b/backend/src/main/java/moim_today/domain/moim/ViewedMoim.java
@@ -1,0 +1,23 @@
+package moim_today.domain.moim;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ViewedMoim(
+        long moimId,
+        LocalDateTime expiredTime
+){
+
+    public static ViewedMoim of(long moimId, LocalDateTime expiredTime) {
+        return ViewedMoim.builder()
+                .moimId(moimId)
+                .expiredTime(expiredTime)
+                .build();
+    }
+
+    public boolean isExpired() {
+        return expiredTime.isBefore(LocalDateTime.now());
+    }
+}

--- a/backend/src/main/java/moim_today/domain/moim/ViewedMoimsCookie.java
+++ b/backend/src/main/java/moim_today/domain/moim/ViewedMoimsCookie.java
@@ -17,18 +17,39 @@ import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
 import static moim_today.global.constant.NumberConstant.ONE_DAY;
 import static moim_today.global.constant.NumberConstant.ONE_DAYS_IN_SECONDS;
 import static moim_today.global.constant.exception.MoimExceptionConstant.VIEWED_MOIM_JSON_PROCESSING_ERROR;
+import static moim_today.global.constant.exception.MoimExceptionConstant.VIEWED_MOIM_NOT_FOUND_ERROR;
 
 public record ViewedMoimsCookie(
         List<ViewedMoim> viewedMoims
 ) {
 
-    public boolean existsInViewedMoims(final long moimId) {
-        return viewedMoims.stream().map(ViewedMoim::moimId).toList().contains(moimId);
+    public static ViewedMoimsCookie createViewedMoimsCookieOrDefault(final String viewedMoimsCookieByUrlEncoded,
+                                                                     final List<ViewedMoim> defaultViewedMoims,
+                                                                     final ObjectMapper objectMapper) {
+        if (viewedMoimsCookieByUrlEncoded != null) {
+            return parseViewedMoimsCookie(viewedMoimsCookieByUrlEncoded, objectMapper);
+        } else {
+            return new ViewedMoimsCookie(defaultViewedMoims);
+        }
     }
 
     public void createAndAddViewedMoim(final long moimId) {
         ViewedMoim viewedMoim = ViewedMoim.of(moimId, LocalDateTime.now().plusDays(ONE_DAY.value()));
         viewedMoims.add(viewedMoim);
+    }
+
+    public void removeViewedMoim(final long moimId) {
+        ViewedMoim viewedMoim = getViewedMoim(moimId);
+        viewedMoims.remove(viewedMoim);
+    }
+
+    public boolean existsInViewedMoims(final long moimId) {
+        return viewedMoims.stream().map(ViewedMoim::moimId).toList().contains(moimId);
+    }
+
+    public boolean isExpired(final long moimId) {
+        ViewedMoim viewedMoim = getViewedMoim(moimId);
+        return viewedMoim.isExpired();
     }
 
     public void addViewedMoimsCookieInCookie(final HttpServletResponse response, final ObjectMapper objectMapper) {
@@ -38,26 +59,6 @@ public record ViewedMoimsCookie(
         cookie.setSecure(true);
         cookie.setMaxAge(ONE_DAYS_IN_SECONDS.value());
         response.addCookie(cookie);
-    }
-
-    public static ViewedMoimsCookie getViewedMoimsCookieOrDefault(final String viewedMoimsCookieByUrlEncoded,
-                                                           final List<ViewedMoim> defaultViewedMoims,
-                                                           final ObjectMapper objectMapper) {
-        if (viewedMoimsCookieByUrlEncoded != null) {
-            return parseViewedMoimsCookie(viewedMoimsCookieByUrlEncoded, objectMapper);
-        } else {
-            return new ViewedMoimsCookie(defaultViewedMoims);
-        }
-    }
-
-    public boolean isExpired(final long moimId) {
-        ViewedMoim viewedMoim = getViewedMoim(moimId);
-        return viewedMoim.isExpired();
-    }
-
-    public void removeViewedMoim(final long moimId) {
-        ViewedMoim viewedMoim = getViewedMoim(moimId);
-        viewedMoims.remove(viewedMoim);
     }
 
     private static ViewedMoimsCookie parseViewedMoimsCookie(final String viewedMoimsCookieByUrlEncoded, final ObjectMapper objectMapper) {
@@ -83,6 +84,6 @@ public record ViewedMoimsCookie(
         return viewedMoims.stream()
                 .filter(viewedMoim -> viewedMoim.moimId() == moimId)
                 .findFirst()
-                .orElseThrow(() -> new InternalServerException(VIEWED_MOIM_JSON_PROCESSING_ERROR.message()));
+                .orElseThrow(() -> new InternalServerException(VIEWED_MOIM_NOT_FOUND_ERROR.message()));
     }
 }

--- a/backend/src/main/java/moim_today/domain/moim/ViewedMoimsCookie.java
+++ b/backend/src/main/java/moim_today/domain/moim/ViewedMoimsCookie.java
@@ -1,0 +1,88 @@
+package moim_today.domain.moim;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import moim_today.global.error.InternalServerException;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
+import static moim_today.global.constant.NumberConstant.ONE_DAY;
+import static moim_today.global.constant.NumberConstant.ONE_DAYS_IN_SECONDS;
+import static moim_today.global.constant.exception.MoimExceptionConstant.VIEWED_MOIM_JSON_PROCESSING_ERROR;
+
+public record ViewedMoimsCookie(
+        List<ViewedMoim> viewedMoims
+) {
+
+    public boolean existsInViewedMoims(final long moimId) {
+        return viewedMoims.stream().map(ViewedMoim::moimId).toList().contains(moimId);
+    }
+
+    public void createAndAddViewedMoim(final long moimId) {
+        ViewedMoim viewedMoim = ViewedMoim.of(moimId, LocalDateTime.now().plusDays(ONE_DAY.value()));
+        viewedMoims.add(viewedMoim);
+    }
+
+    public void addViewedMoimsCookieInCookie(final HttpServletResponse response, final ObjectMapper objectMapper) {
+        String viewedMoimsCookieJson = this.toJson(objectMapper);
+        Cookie cookie = new Cookie(VIEWED_MOIM_COOKIE_NAME, URLEncoder.encode(viewedMoimsCookieJson, UTF_8));
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge(ONE_DAYS_IN_SECONDS.value());
+        response.addCookie(cookie);
+    }
+
+    public static ViewedMoimsCookie getViewedMoimsCookieOrDefault(final String viewedMoimsCookieByUrlEncoded,
+                                                           final List<ViewedMoim> defaultViewedMoims,
+                                                           final ObjectMapper objectMapper) {
+        if (viewedMoimsCookieByUrlEncoded != null) {
+            return parseViewedMoimsCookie(viewedMoimsCookieByUrlEncoded, objectMapper);
+        } else {
+            return new ViewedMoimsCookie(defaultViewedMoims);
+        }
+    }
+
+    public boolean isExpired(final long moimId) {
+        ViewedMoim viewedMoim = getViewedMoim(moimId);
+        return viewedMoim.isExpired();
+    }
+
+    public void removeViewedMoim(final long moimId) {
+        ViewedMoim viewedMoim = getViewedMoim(moimId);
+        viewedMoims.remove(viewedMoim);
+    }
+
+    private static ViewedMoimsCookie parseViewedMoimsCookie(final String viewedMoimsCookieByUrlEncoded, final ObjectMapper objectMapper) {
+        String viewedMoimsCookieStringValue = URLDecoder.decode(viewedMoimsCookieByUrlEncoded, UTF_8);
+
+        try {
+            List<ViewedMoim> viewedMoims = objectMapper.readValue(viewedMoimsCookieStringValue, new TypeReference<>() {});
+            return new ViewedMoimsCookie(viewedMoims);
+        } catch (JsonProcessingException e) {
+            throw new InternalServerException(VIEWED_MOIM_JSON_PROCESSING_ERROR.message());
+        }
+    }
+
+    private String toJson(final ObjectMapper objectMapper) {
+        try {
+            return objectMapper.writeValueAsString(viewedMoims);
+        } catch (JsonProcessingException e) {
+            throw new InternalServerException(VIEWED_MOIM_JSON_PROCESSING_ERROR.message());
+        }
+    }
+
+    private ViewedMoim getViewedMoim(final long moimId) {
+        return viewedMoims.stream()
+                .filter(viewedMoim -> viewedMoim.moimId() == moimId)
+                .findFirst()
+                .orElseThrow(() -> new InternalServerException(VIEWED_MOIM_JSON_PROCESSING_ERROR.message()));
+    }
+}

--- a/backend/src/main/java/moim_today/domain/moim/ViewedMoimsCookie.java
+++ b/backend/src/main/java/moim_today/domain/moim/ViewedMoimsCookie.java
@@ -44,7 +44,10 @@ public record ViewedMoimsCookie(
     }
 
     public boolean existsInViewedMoims(final long moimId) {
-        return viewedMoims.stream().map(ViewedMoim::moimId).toList().contains(moimId);
+        return viewedMoims.stream()
+                .map(ViewedMoim::moimId)
+                .toList()
+                .contains(moimId);
     }
 
     public boolean isExpired(final long moimId) {

--- a/backend/src/main/java/moim_today/global/config/WebConfig.java
+++ b/backend/src/main/java/moim_today/global/config/WebConfig.java
@@ -28,7 +28,6 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/api/login",
                         "/api/certification/**",
-                        "/api/moims/detail",
                         "/api/sign-up",
                         "/api/universities",
                         "/api/universities/departments/**",

--- a/backend/src/main/java/moim_today/global/constant/MoimConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/MoimConstant.java
@@ -5,6 +5,8 @@ public enum MoimConstant {
     DEFAULT_MOIM_IMAGE_URL("https://anak2.s3.ap-northeast-2.amazonaws.com/moim/default-moim.jpg"),
     DEFAULT_MOIM_PASSWORD("NONE");
 
+    public static final String VIEWED_MOIM_COOKIE_NAME = "VIEWEDMOIMS";
+
     private final String value;
 
     MoimConstant(final String value) {

--- a/backend/src/main/java/moim_today/global/constant/NumberConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/NumberConstant.java
@@ -10,6 +10,7 @@ public enum NumberConstant {
 
     DEFAULT_MOIM_CURRENT_COUNT(1),
     DEFAULT_MOIM_VIEWS(0),
+    VIEW_COUNT_OF_ONE(1),
 
     SCHEDULE_MEETING_ID(0),
     SCHEDULE_MOIM_ID(0),
@@ -24,7 +25,8 @@ public enum NumberConstant {
 
     NOT_EXIST_IDX(-1),
     THIRTY_DAYS_IN_SECONDS(2592000),
-    ONE_DAYS_IN_SECONDS(3600);
+    ONE_DAYS_IN_SECONDS(3600),
+    ONE_DAY(1);
 
     private final int value;
 

--- a/backend/src/main/java/moim_today/global/constant/exception/MoimExceptionConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/exception/MoimExceptionConstant.java
@@ -9,7 +9,9 @@ public enum MoimExceptionConstant {
     MOIM_FORBIDDEN_ERROR("해당 모임에 대한 접근 권한이 없습니다."),
     NOTICE_NOT_FOUND_ERROR("존재하지 않거나 삭제된 공지입니다."),
     ORGANIZER_FORBIDDEN_ERROR("모임장만 접근할 수 있습니다."),
-    JOINED_MOIM_MEMBER_IS_EMPTY("모임에 참여한 멤버가 없습니다.");
+    JOINED_MOIM_MEMBER_IS_EMPTY("모임에 참여한 멤버가 없습니다."),
+    VIEWED_MOIM_JSON_PROCESSING_ERROR("서버 내부 오류가 발생했습니다. 조회수를 처리하는 중 문제가 발생했습니다.");
+
 
     private final String message;
 

--- a/backend/src/main/java/moim_today/global/constant/exception/MoimExceptionConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/exception/MoimExceptionConstant.java
@@ -10,8 +10,8 @@ public enum MoimExceptionConstant {
     NOTICE_NOT_FOUND_ERROR("존재하지 않거나 삭제된 공지입니다."),
     ORGANIZER_FORBIDDEN_ERROR("모임장만 접근할 수 있습니다."),
     JOINED_MOIM_MEMBER_IS_EMPTY("모임에 참여한 멤버가 없습니다."),
-    VIEWED_MOIM_JSON_PROCESSING_ERROR("서버 내부 오류가 발생했습니다. 조회수를 처리하는 중 문제가 발생했습니다.");
-
+    VIEWED_MOIM_JSON_PROCESSING_ERROR("서버 내부 오류가 발생했습니다. 조회수를 처리하는 중 문제가 발생했습니다."),
+    VIEWED_MOIM_NOT_FOUND_ERROR("서버 내부 오류가 발생했습니다. 모임 ID를 쿠키에서 조회하는 중 문제가 발생했습니다.");
 
     private final String message;
 

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimUpdater.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimUpdater.java
@@ -1,18 +1,25 @@
 package moim_today.implement.moim.moim;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import moim_today.domain.moim.ViewedMoimsCookie;
 import moim_today.dto.moim.moim.MoimUpdateRequest;
 import moim_today.global.annotation.Implement;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+
 @Implement
 public class MoimUpdater {
 
     private final MoimRepository moimRepository;
+    private final ObjectMapper objectMapper;
 
-    public MoimUpdater(final MoimRepository moimRepository) {
+    public MoimUpdater(final MoimRepository moimRepository, final ObjectMapper objectMapper) {
         this.moimRepository = moimRepository;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional
@@ -20,5 +27,24 @@ public class MoimUpdater {
         MoimJpaEntity moimJpaEntity = moimRepository.getById(moimUpdateRequest.moimId());
         moimJpaEntity.validateHostMember(memberId);
         moimJpaEntity.updateMoim(moimUpdateRequest);
+    }
+
+    @Transactional
+    public void updateMoimViews(final MoimJpaEntity moimJpaEntity, final String viewedMoimsCookieByUrlEncoded, final HttpServletResponse response) {
+        ViewedMoimsCookie viewedMoimsCookie = ViewedMoimsCookie.getViewedMoimsCookieOrDefault(
+                viewedMoimsCookieByUrlEncoded, new ArrayList<>(), objectMapper);
+
+        if (!viewedMoimsCookie.existsInViewedMoims(moimJpaEntity.getId())) {
+            moimJpaEntity.updateMoimViews();
+            viewedMoimsCookie.createAndAddViewedMoim(moimJpaEntity.getId());
+            viewedMoimsCookie.addViewedMoimsCookieInCookie(response, objectMapper);
+            return;
+        }
+
+        if (viewedMoimsCookie.isExpired(moimJpaEntity.getId())) {
+            viewedMoimsCookie.removeViewedMoim(moimJpaEntity.getId());
+            viewedMoimsCookie.createAndAddViewedMoim(moimJpaEntity.getId());
+            viewedMoimsCookie.addViewedMoimsCookieInCookie(response, objectMapper);
+        }
     }
 }

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimUpdater.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimUpdater.java
@@ -44,10 +44,7 @@ public class MoimUpdater {
             moimJpaEntity.updateMoimViews();
             viewedMoimsCookie.createAndAddViewedMoim(moimId);
             viewedMoimsCookie.addViewedMoimsCookieInCookie(response, objectMapper);
-            return;
-        }
-
-        if (viewedMoimsCookie.isExpired(moimId)) {
+        } else if (viewedMoimsCookie.isExpired(moimId)) {
             moimJpaEntity.updateMoimViews();
             viewedMoimsCookie.removeViewedMoim(moimId);
             viewedMoimsCookie.createAndAddViewedMoim(moimId);

--- a/backend/src/main/java/moim_today/persistence/entity/moim/moim/MoimJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/moim/moim/MoimJpaEntity.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import static moim_today.global.constant.MoimConstant.DEFAULT_MOIM_IMAGE_URL;
 import static moim_today.global.constant.MoimConstant.DEFAULT_MOIM_PASSWORD;
 import static moim_today.global.constant.exception.MoimExceptionConstant.MOIM_HOST_ERROR;
+import static moim_today.global.constant.NumberConstant.VIEW_COUNT_OF_ONE;
 import static moim_today.global.constant.exception.MoimExceptionConstant.ORGANIZER_FORBIDDEN_ERROR;
 
 @Getter
@@ -22,7 +23,8 @@ import static moim_today.global.constant.exception.MoimExceptionConstant.ORGANIZ
 @Entity
 public class MoimJpaEntity extends BaseTimeEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "moim_id")
     private long id;
 
@@ -125,5 +127,9 @@ public class MoimJpaEntity extends BaseTimeEntity {
                 this.password = updatePassword;
             }
         }
+    }
+
+    public void updateMoimViews() {
+        this.views += VIEW_COUNT_OF_ONE.value();
     }
 }

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -40,8 +40,8 @@ public class MoimController {
         return moimService.uploadMoimImage(file);
     }
 
-    @GetMapping("/detail")
-    public MoimDetailResponse getMoimDetail(@RequestParam final long moimId,
+    @GetMapping("/detail/{moimId}")
+    public MoimDetailResponse getMoimDetail(@PathVariable final long moimId,
                                             @CookieValue(value = VIEWED_MOIM_COOKIE_NAME, required = false) final String viewedMoimsCookieByUrlEncoded,
                                             final HttpServletResponse response) {
         return moimService.getMoimDetail(moimId, viewedMoimsCookieByUrlEncoded, response);

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -1,5 +1,6 @@
 package moim_today.presentation.moim;
 
+import jakarta.servlet.http.HttpServletResponse;
 import moim_today.application.moim.moim.MoimService;
 import moim_today.application.moim.moim_notice.MoimNoticeService;
 import moim_today.domain.member.MemberSession;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
+import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
 
 @RequestMapping("/api/moims")
 @RestController
@@ -38,8 +41,10 @@ public class MoimController {
     }
 
     @GetMapping("/detail")
-    public MoimDetailResponse getMoimDetail(@RequestParam final long moimId) {
-        return moimService.getMoimDetail(moimId);
+    public MoimDetailResponse getMoimDetail(@RequestParam final long moimId,
+                                            @CookieValue(value = VIEWED_MOIM_COOKIE_NAME, required = false) final String viewedMoimsCookieByUrlEncoded,
+                                            final HttpServletResponse response) {
+        return moimService.getMoimDetail(moimId, viewedMoimsCookieByUrlEncoded, response);
     }
 
     @GetMapping("/simple")

--- a/backend/src/test/java/moim_today/domain/moim/ViewedMoimTest.java
+++ b/backend/src/test/java/moim_today/domain/moim/ViewedMoimTest.java
@@ -1,0 +1,41 @@
+package moim_today.domain.moim;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ViewedMoimTest {
+
+    @DisplayName("만료시간이 지났으면 ture를 반환한다.")
+    @Test
+    void isExpiredTrueTest() {
+        //given
+        ViewedMoim viewedMoim = ViewedMoim.builder()
+                .expiredTime(LocalDateTime.now().minusDays(1))
+                .build();
+
+        //when
+        boolean isExpired = viewedMoim.isExpired();
+
+        //then
+        assertThat(isExpired).isTrue();
+    }
+
+    @DisplayName("만료시간이 지나지 않았으면 false를 반환한다.")
+    @Test
+    void isExpiredFalseTest() {
+        //given
+        ViewedMoim viewedMoim = ViewedMoim.builder()
+                .expiredTime(LocalDateTime.now().plusDays(1))
+                .build();
+
+        //when
+        boolean isExpired = viewedMoim.isExpired();
+
+        //then
+        assertThat(isExpired).isFalse();
+    }
+}

--- a/backend/src/test/java/moim_today/domain/moim/ViewedMoimsCookieTest.java
+++ b/backend/src/test/java/moim_today/domain/moim/ViewedMoimsCookieTest.java
@@ -1,0 +1,261 @@
+package moim_today.domain.moim;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import moim_today.global.error.InternalServerException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
+import static moim_today.global.constant.NumberConstant.ONE_DAYS_IN_SECONDS;
+import static moim_today.global.constant.exception.MoimExceptionConstant.VIEWED_MOIM_NOT_FOUND_ERROR;
+import static moim_today.util.SerializingObjectMapper.serializingObjectMapper;
+import static moim_today.util.TestConstant.LOCAL_DATE_TIME_FORMAT;
+import static moim_today.util.TestConstant.MOIM_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ViewedMoimsCookieTest {
+
+    private final ObjectMapper objectMapper = serializingObjectMapper();
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern(LOCAL_DATE_TIME_FORMAT.value());
+
+
+    @DisplayName("URL 인코딩된 쿠키가 없으면 default 값을 생성하여 반환한다.")
+    @Test
+    void createDefaultCookie() {
+        //given
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        //when
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //then
+        List<ViewedMoim> viewedMoims = viewedMoimsCookie.viewedMoims();
+        assertThat(viewedMoims.size()).isEqualTo(0);
+    }
+
+    @DisplayName("URL 인코딩된 쿠키가 있으면 값을 파싱하여 생성한뒤 반환한다.")
+    @Test
+    void createByViewedMoimsCookieByUrlEncodedCookie() {
+        //given1
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+        String format = LocalDateTime.now().plusDays(1).format(DATETIME_FORMATTER);
+        LocalDateTime expiredTime = LocalDateTime.parse(format, DATETIME_FORMATTER);
+
+        ViewedMoimsCookie viewedMoimsCookieParameter =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        long moimId = MOIM_ID.longValue();
+        ViewedMoim viewedMoim = ViewedMoim.of(moimId, expiredTime);
+        viewedMoimsCookieParameter.viewedMoims().add(viewedMoim);
+        viewedMoimsCookieParameter.addViewedMoimsCookieInCookie(response, objectMapper);
+        String viewedMoimsCookieByUrlEncodedParameter = requireNonNull(response.getCookie(VIEWED_MOIM_COOKIE_NAME)).getValue();
+
+        //when
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        viewedMoimsCookieByUrlEncodedParameter,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //then
+        List<ViewedMoim> viewedMoims = viewedMoimsCookie.viewedMoims();
+        assertThat(viewedMoims.size()).isEqualTo(1);
+        assertThat(viewedMoims.get(0).moimId()).isEqualTo(moimId);
+        assertThat(viewedMoims.get(0).expiredTime()).isEqualTo(expiredTime);
+    }
+
+    @DisplayName("모임Id로 만료 기간이 하루 뒤인 ViewedMoim를 생성하고 쿠키 리스트에 추가한다.")
+    @Test
+    void createAndAddViewedMoimTest() {
+        //given1
+        LocalDateTime testStartTime = LocalDateTime.now();
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        long moimId = MOIM_ID.longValue();
+
+        //when
+        viewedMoimsCookie.createAndAddViewedMoim(moimId);
+
+        //then
+        LocalDateTime testEndTime = LocalDateTime.now();
+        List<ViewedMoim> viewedMoims = viewedMoimsCookie.viewedMoims();
+        assertThat(viewedMoims.size()).isEqualTo(1);
+        assertThat(viewedMoims.get(0).moimId()).isEqualTo(moimId);
+        assertThat(viewedMoims.get(0).expiredTime()).isAfter(testStartTime.plusDays(1).minusMinutes(1));
+        assertThat(viewedMoims.get(0).expiredTime()).isBefore(testEndTime.plusDays(1).plusMinutes(1));
+    }
+
+    @DisplayName("모임Id로 ViewedMoim를 쿠키 리스트에서 제거한다.")
+    @Test
+    void removeViewedMoimTest() {
+        //given1
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        long moimId = MOIM_ID.longValue();
+        ViewedMoim viewedMoim = ViewedMoim.of(moimId, LocalDateTime.now());
+        viewedMoimsCookie.viewedMoims().add(viewedMoim);
+
+        //when
+        viewedMoimsCookie.removeViewedMoim(moimId);
+
+        //then
+        List<ViewedMoim> viewedMoims = viewedMoimsCookie.viewedMoims();
+        assertThat(viewedMoims.size()).isEqualTo(0);
+    }
+
+    @DisplayName("모임Id로 ViewedMoim를 제거 할때, 쿠키 리스트에 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void removeViewedMoimThrowsExceptionTest() {
+        //given1
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        long notExistMoimId = MOIM_ID.longValue();
+
+        //expected
+        assertThatThrownBy(() -> viewedMoimsCookie.removeViewedMoim(notExistMoimId))
+                .isInstanceOf(InternalServerException.class)
+                .hasMessage(VIEWED_MOIM_NOT_FOUND_ERROR.message());
+    }
+
+    @DisplayName("쿠키 리스트에 모임 Id에 해당하는 ViewedMoim가 존재하는지 확인한다.")
+    @Test
+    void existsInViewedMoimsTest() {
+        //given1
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        long existMoimId = MOIM_ID.longValue();
+        long notExistMoimId = MOIM_ID.longValue() + 1;
+        ViewedMoim viewedMoim = ViewedMoim.of(existMoimId, LocalDateTime.now());
+        viewedMoimsCookie.viewedMoims().add(viewedMoim);
+
+        //when
+        boolean existsInViewedMoims = viewedMoimsCookie.existsInViewedMoims(existMoimId);
+        boolean notExistsInViewedMoims = viewedMoimsCookie.existsInViewedMoims(notExistMoimId);
+
+        //then
+        assertThat(existsInViewedMoims).isTrue();
+        assertThat(notExistsInViewedMoims).isFalse();
+    }
+
+    @DisplayName("쿠키 리스트에 모임 Id에 해당하는 ViewedMoim가 만료되었는지 확인한다.")
+    @Test
+    void isExpiredTest() {
+        //given1
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        long expiredMoimId = MOIM_ID.longValue();
+        long notExpiredMoimId = MOIM_ID.longValue() + 1;
+
+        ViewedMoim expiredViewedMoim = ViewedMoim.of(expiredMoimId, LocalDateTime.now().minusDays(1));
+        ViewedMoim notExpiredViewedMoim = ViewedMoim.of(notExpiredMoimId, LocalDateTime.now().plusDays(1));
+        viewedMoimsCookie.viewedMoims().add(expiredViewedMoim);
+        viewedMoimsCookie.viewedMoims().add(notExpiredViewedMoim);
+
+        //when
+        boolean expectedExpiredTrue = viewedMoimsCookie.isExpired(expiredMoimId);
+        boolean expectedExpiredFalse = viewedMoimsCookie.isExpired(notExpiredMoimId);
+
+        //then
+        assertThat(expectedExpiredTrue).isTrue();
+        assertThat(expectedExpiredFalse).isFalse();
+    }
+
+    @DisplayName("쿠키 리스트를 응답에 설정한다.")
+    @Test
+    void addViewedMoimsCookieInCookieTest() {
+        //given1
+        String nullOfViewedMoimsCookieByUrlEncoded = null;
+        List<ViewedMoim> defaultViewedMoims = new ArrayList<>();
+
+        ViewedMoimsCookie viewedMoimsCookie =
+                ViewedMoimsCookie.createViewedMoimsCookieOrDefault(
+                        nullOfViewedMoimsCookieByUrlEncoded,
+                        defaultViewedMoims,
+                        objectMapper
+                );
+
+        //given2
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        //when
+        viewedMoimsCookie.addViewedMoimsCookieInCookie(response, objectMapper);
+
+        //then
+        Cookie cookie = response.getCookie(VIEWED_MOIM_COOKIE_NAME);
+        assertThat(cookie).isNotNull();
+        assertThat(cookie.getValue()).isNotNull();
+        assertThat(cookie.getMaxAge()).isEqualTo(ONE_DAYS_IN_SECONDS.value());
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getSecure()).isTrue();
+    }
+}

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -1,5 +1,6 @@
 package moim_today.fake_class.moim;
 
+import jakarta.servlet.http.HttpServletResponse;
 import moim_today.application.moim.moim.MoimService;
 import moim_today.domain.moim.DisplayStatus;
 import moim_today.domain.moim.enums.MoimCategory;
@@ -30,7 +31,9 @@ public class FakeMoimService implements MoimService {
     }
 
     @Override
-    public MoimDetailResponse getMoimDetail(final long moimId) {
+    public MoimDetailResponse getMoimDetail(final long moimId,
+                                            final String viewedMoimsCookieByUrlEncoded,
+                                            final HttpServletResponse response) {
         return MoimDetailResponse.builder()
                 .moimId(moimId)
                 .title(MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/persistence/entity/moim/moim/MoimJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/moim/moim/MoimJpaEntityTest.java
@@ -237,4 +237,19 @@ class MoimJpaEntityTest {
         assertThat(moimJpaEntity.getStartDate()).isEqualTo(startDate);
         assertThat(moimJpaEntity.getEndDate()).isEqualTo(endDate);
     }
+
+    @DisplayName("조회수를 1 올린다.")
+    @Test
+    void updateViewsTest(){
+        //given
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .views(0)
+                .build();
+
+        //when
+        moimJpaEntity.updateMoimViews();
+
+        //then
+        assertThat(moimJpaEntity.getViews()).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -17,13 +17,11 @@ import moim_today.util.EnumDocsUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockCookie;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDate;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -118,15 +116,13 @@ class MoimControllerTest extends ControllerTest {
     @Test
     void getMoimDetailTest() throws Exception {
 
-        mockMvc.perform(get("/api/moims/detail")
-                        .param("moimId", "1")
-                )
+        mockMvc.perform(get("/api/moims/detail/{moimId}", 1))
                 .andExpect(status().isOk())
                 .andDo(document("모임 정보 조회 성공",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("모임")
                                 .summary("모임 정보 조회")
-                                .queryParameters(
+                                .pathParameters(
                                         parameterWithName("moimId").description("모임 ID")
                                 )
                                 .responseFields(
@@ -244,8 +240,7 @@ class MoimControllerTest extends ControllerTest {
     @DisplayName("모임에서 멤버를 조회한다")
     @Test
     void showMoimMemberTest() throws Exception {
-        mockMvc.perform(get("/api/moims/members/{moimId}", 1L)
-                        .param("moimId", MEMBER_ID.value()))
+        mockMvc.perform(get("/api/moims/members/{moimId}", 1L))
                 .andExpect(status().isOk())
                 .andDo(document("모임 멤버 조회",
                         pathParameters(

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -17,11 +17,13 @@ import moim_today.util.EnumDocsUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockCookie;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDate;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
 import static moim_today.util.TestConstant.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;

--- a/backend/src/test/java/moim_today/util/ControllerTest.java
+++ b/backend/src/test/java/moim_today/util/ControllerTest.java
@@ -1,9 +1,6 @@
 package moim_today.util;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import moim_today.fake_class.global.FakeInterceptor;
 import moim_today.global.argumentresolver.MemberLoginArgumentResolver;
 import moim_today.global.error.ApiRestControllerAdvice;
@@ -14,12 +11,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
-import static moim_today.util.TestConstant.*;
+import static moim_today.util.SerializingObjectMapper.serializingObjectMapper;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 
 @ExtendWith(RestDocumentationExtension.class)
@@ -29,9 +21,6 @@ public abstract class ControllerTest {
 
     protected ObjectMapper objectMapper = serializingObjectMapper();
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(LOCAL_DATE_FORMAT.value());
-    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern(LOCAL_DATE_TIME_FORMAT.value());
-
     @BeforeEach
     void setUp(final RestDocumentationContextProvider provider) {
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
@@ -40,51 +29,6 @@ public abstract class ControllerTest {
                 .addInterceptors(new FakeInterceptor(objectMapper))
                 .apply(documentationConfiguration(provider))
                 .build();
-    }
-
-    private ObjectMapper serializingObjectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        JavaTimeModule javaTimeModule = new JavaTimeModule();
-
-        javaTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer());
-        javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer());
-        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
-        javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
-        objectMapper.registerModule(javaTimeModule);
-
-        return objectMapper;
-    }
-
-    private static class LocalDateSerializer extends JsonSerializer<LocalDate> {
-
-        @Override
-        public void serialize(final LocalDate value, JsonGenerator gen, final SerializerProvider serializers) throws IOException {
-            gen.writeString(value.format(DATE_FORMATTER));
-        }
-    }
-
-    private static class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
-
-        @Override
-        public LocalDate deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
-            return LocalDate.parse(p.getValueAsString(), DATE_FORMATTER);
-        }
-    }
-
-    private static class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
-
-        @Override
-        public void serialize(final LocalDateTime value, final JsonGenerator gen, final SerializerProvider serializerProvider) throws IOException {
-            gen.writeString(value.format(DATETIME_FORMATTER));
-        }
-    }
-
-    private static class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
-
-        @Override
-        public LocalDateTime deserialize(final JsonParser p, final DeserializationContext deserializationContext) throws IOException {
-            return LocalDateTime.parse(p.getValueAsString(), DATETIME_FORMATTER);
-        }
     }
 
     protected abstract Object initController();

--- a/backend/src/test/java/moim_today/util/SerializingObjectMapper.java
+++ b/backend/src/test/java/moim_today/util/SerializingObjectMapper.java
@@ -1,0 +1,65 @@
+package moim_today.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static moim_today.util.TestConstant.LOCAL_DATE_FORMAT;
+import static moim_today.util.TestConstant.LOCAL_DATE_TIME_FORMAT;
+
+public class SerializingObjectMapper {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(LOCAL_DATE_FORMAT.value());
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern(LOCAL_DATE_TIME_FORMAT.value());
+
+    public static ObjectMapper serializingObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+        javaTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer());
+        javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer());
+        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+        javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+        objectMapper.registerModule(javaTimeModule);
+
+        return objectMapper;
+    }
+
+    private static class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+        @Override
+        public void serialize(final LocalDate value, JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+            gen.writeString(value.format(DATE_FORMATTER));
+        }
+    }
+
+    private static class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
+
+        @Override
+        public LocalDate deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+            return LocalDate.parse(p.getValueAsString(), DATE_FORMATTER);
+        }
+    }
+
+    private static class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+
+        @Override
+        public void serialize(final LocalDateTime value, final JsonGenerator gen, final SerializerProvider serializerProvider) throws IOException {
+            gen.writeString(value.format(DATETIME_FORMATTER));
+        }
+    }
+
+    private static class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+        @Override
+        public LocalDateTime deserialize(final JsonParser p, final DeserializationContext deserializationContext) throws IOException {
+            return LocalDateTime.parse(p.getValueAsString(), DATETIME_FORMATTER);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #87 

## 📝작업 내용

> 모임 증가시 조회수 증가 로직 구현
> 테스트
> 테스트 ObjectMapper 클래스 분리


## 💬리뷰 요구사항

> `Cookie`에 `value`를 넣을때, `value`값에 특수 문자나 공백이 들어갈 수 없는 문제가 있어서 `URLEncoder`, `URLDecoder`를 사용했습니다.
> 모임 조회시 `updateMoimViews`로직을 추가했으니 이 점 위주로 봐주시면 될 것 같습니당.