### PR TITLE
[BE] hotfix : 멤버가 모임에 참여할 때  모임의 currentCount 도 검사하도록 수정

### DIFF
--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
@@ -45,7 +45,7 @@ public class MoimFinder {
     }
 
     @Transactional
-    public MoimJpaEntity getByIdWithPessimisticLock(final long moimId){
+    public MoimJpaEntity getByIdWithPessimisticLock(final long moimId) {
         return moimRepository.getByIdWithPessimisticLock(moimId);
     }
 
@@ -78,10 +78,11 @@ public class MoimFinder {
     }
 
     @Transactional(readOnly = true)
-    public void validateCapacity(final MoimJpaEntity moimJpaEntity){
+    public void validateCapacity(final MoimJpaEntity moimJpaEntity) {
         long moimId = moimJpaEntity.getId();
         List<Long> participatingMemberIds = joinedMoimFinder.findAllJoinedMemberId(moimId);
-        if(participatingMemberIds.size() >= moimJpaEntity.getCapacity()){
+        if (participatingMemberIds.size() >= moimJpaEntity.getCapacity()
+                || !moimJpaEntity.checkVacancy()) {
             throw new BadRequestException(MOIM_CAPACITY_ERROR.message());
         }
     }
@@ -91,7 +92,7 @@ public class MoimFinder {
         return moimRepository.searchMoimBySearchParam(searchParam);
     }
 
-    private List<Long> extractMemberIds(final List<JoinedMoimJpaEntity> joinedMoimJpaEntities){
+    private List<Long> extractMemberIds(final List<JoinedMoimJpaEntity> joinedMoimJpaEntities) {
         List<Long> memberIds = new ArrayList<>();
         joinedMoimJpaEntities.forEach(e -> memberIds.add(e.getMemberId()));
         return memberIds;

--- a/backend/src/main/java/moim_today/persistence/entity/moim/moim/MoimJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/moim/moim/MoimJpaEntity.java
@@ -132,4 +132,8 @@ public class MoimJpaEntity extends BaseTimeEntity {
     public void updateMoimViews() {
         this.views += VIEW_COUNT_OF_ONE.value();
     }
+
+    public boolean checkVacancy(){
+        return currentCount < capacity;
+    }
 }

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
@@ -318,7 +318,7 @@ class MoimFinderTest extends ImplementTest {
         assertThat(moimSimpleResponses.get(0).title()).isEqualTo(FIRST_CREATED_MOIM_TITLE.value());
     }
 
-    @DisplayName("모임에 여석이 있는지 검사하고, 꽉 차면 에러를 발생시킨다.")
+    @DisplayName("모임에 여석이 있는지 검사하고, 꽉 차있으면 에러를 발생시킨다.")
     @Test
     void validateCapacityThrowError() {
         // given1
@@ -331,15 +331,24 @@ class MoimFinderTest extends ImplementTest {
         MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
                 .memberId(hostId)
                 .capacity(1)
+                .currentCount(1)
                 .build();
 
         MoimJpaEntity moimJpaEntity2 = MoimJpaEntity.builder()
                 .memberId(hostId)
                 .capacity(3)
+                .currentCount(3)
+                .build();
+
+        MoimJpaEntity moimJpaEntity3 = MoimJpaEntity.builder()
+                .memberId(hostId)
+                .capacity(100)
+                .currentCount(100)
                 .build();
 
         MoimJpaEntity savedMoim1 = moimRepository.save(moimJpaEntity1);
         MoimJpaEntity savedMoim2 = moimRepository.save(moimJpaEntity2);
+        MoimJpaEntity savedMoim3 = moimRepository.save(moimJpaEntity3);
 
         // given3
         JoinedMoimJpaEntity jm1 = saveJoinedMoim(savedMoim1.getId(), hostId);
@@ -354,6 +363,9 @@ class MoimFinderTest extends ImplementTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(MOIM_CAPACITY_ERROR.message());
         assertThatThrownBy(() -> moimFinder.validateCapacity(savedMoim2))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MOIM_CAPACITY_ERROR.message());
+        assertThatThrownBy(() -> moimFinder.validateCapacity(savedMoim3))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(MOIM_CAPACITY_ERROR.message());
     }
@@ -371,11 +383,19 @@ class MoimFinderTest extends ImplementTest {
         MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
                 .memberId(hostId)
                 .capacity(4)
+                .currentCount(3)
                 .build();
 
         MoimJpaEntity moimJpaEntity2 = MoimJpaEntity.builder()
                 .memberId(hostId)
                 .capacity(100)
+                .currentCount(1)
+                .build();
+
+        MoimJpaEntity moimJpaEntity3 = MoimJpaEntity.builder()
+                .memberId(hostId)
+                .capacity(20)
+                .currentCount(19)
                 .build();
 
         MoimJpaEntity savedMoim1 = moimRepository.save(moimJpaEntity1);
@@ -389,9 +409,10 @@ class MoimFinderTest extends ImplementTest {
         JoinedMoimJpaEntity jm5 = saveJoinedMoim(savedMoim2.getId(), member2.getId());
         JoinedMoimJpaEntity jm6 = saveJoinedMoim(savedMoim2.getId(), member3.getId());
 
-
         // expected
         assertThatCode(() -> moimFinder.validateCapacity(savedMoim1))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> moimFinder.validateCapacity(savedMoim2))
                 .doesNotThrowAnyException();
         assertThatCode(() -> moimFinder.validateCapacity(savedMoim2))
                 .doesNotThrowAnyException();

--- a/backend/src/test/java/moim_today/persistence/entity/moim/moim/MoimJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/moim/moim/MoimJpaEntityTest.java
@@ -252,4 +252,23 @@ class MoimJpaEntityTest {
         //then
         assertThat(moimJpaEntity.getViews()).isEqualTo(1);
     }
+
+    @DisplayName("자리가 있는지 검사한다")
+    @Test
+    void checkVacancy() {
+        // given
+        MoimJpaEntity vacancyMoim = MoimJpaEntity.builder()
+                .capacity(5)
+                .currentCount(4)
+                .build();
+
+        MoimJpaEntity noVacancyMoim = MoimJpaEntity.builder()
+                .capacity(5)
+                .currentCount(5)
+                .build();
+
+        // expected
+        assertThat(vacancyMoim.checkVacancy()).isTrue();
+        assertThat(noVacancyMoim.checkVacancy()).isFalse();
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

> 이전 로직에선 joinedMoim 으로 현재 모임에 참여한 멤버의 cnt 를 계산해서 모임의 여석을 계산했는데, 이럴 경우 currentCount에 상관없이 멤버가 가입이 가능한 오류가 있어서 수정했습니다.

## 💬리뷰 요구사항(선택)

joinedMoim 에 실제로 모임에 참여한 멤버의 정보아 currentCount의 정보의 불일치가 예상되는데, 이 부분은 어떻게 처리할 지 고민입니다. 우선 급한대로 or 연산자로 둘 다 validate 하도록 수정했는데, 이러면 currentCount의 숫자와 실제 멤버 숫자가 불일치할 수 있습니다!
