### PR TITLE
[BE] fix : 모임의 멤버 조회할 때 moimId를 이용한 조건을 추가

### DIFF
--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -119,7 +119,8 @@ public class MoimServiceImpl implements MoimService{
         boolean isHostRequest = moimFinder.isHost(memberId, moimId);
 
         List<JoinedMoimJpaEntity> joinedMoimJpaEntities = joinedMoimFinder.findByMoimId(moimId);
-        List<MoimMemberResponse> moimMemberResponses = moimFinder.findMembersInMoim(joinedMoimJpaEntities, moimHostId);
+        List<Long> moimMemberIds = JoinedMoimJpaEntity.extractMemberIds(joinedMoimJpaEntities);
+        List<MoimMemberResponse> moimMemberResponses = moimFinder.findMembersInMoim(moimMemberIds, moimHostId, moimId);
 
         return MoimMemberTabResponse.of(isHostRequest, moimMemberResponses);
     }

--- a/backend/src/main/java/moim_today/implement/member/MemberFinder.java
+++ b/backend/src/main/java/moim_today/implement/member/MemberFinder.java
@@ -47,8 +47,9 @@ public class MemberFinder {
     }
 
     @Transactional(readOnly = true)
-    public List<MoimMemberResponse> findMembersWithJoinedInfo(final List<Long> memberIds, final long hostId) {
-        return memberRepository.findMembersWithJoinInfo(memberIds, hostId);
+    public List<MoimMemberResponse> findMoimMembers(final List<Long> memberIds, final long hostId,
+                                                    final long moimId) {
+        return memberRepository.findMoimMembers(memberIds, hostId, moimId);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
@@ -50,10 +50,9 @@ public class MoimFinder {
     }
 
     @Transactional(readOnly = true)
-    public List<MoimMemberResponse> findMembersInMoim(final List<JoinedMoimJpaEntity> joinedMoimJpaEntities,
-                                                      final long hostId) {
-        List<Long> memberIds = extractMemberIds(joinedMoimJpaEntities);
-        return memberFinder.findMembersWithJoinedInfo(memberIds, hostId);
+    public List<MoimMemberResponse> findMembersInMoim(final List<Long> moimMemberIds, final long hostId,
+                                                      final long moimId) {
+        return memberFinder.findMoimMembers(moimMemberIds, hostId, moimId);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/moim_today/persistence/entity/moim/joined_moim/JoinedMoimJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/moim/joined_moim/JoinedMoimJpaEntity.java
@@ -1,10 +1,13 @@
 package moim_today.persistence.entity.moim.joined_moim;
 
+import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
 import moim_today.global.annotation.Association;
 import moim_today.global.base_entity.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Table(name = "joined_moim")
@@ -35,5 +38,11 @@ public class JoinedMoimJpaEntity extends BaseTimeEntity {
                 .moimId(moimId)
                 .memberId(memberId)
                 .build();
+    }
+
+    public static List<Long> extractMemberIds(final List<JoinedMoimJpaEntity> joinedMoimJpaEntities) {
+        List<Long> memberIds = new ArrayList<>();
+        joinedMoimJpaEntities.forEach(e -> memberIds.add(e.getMemberId()));
+        return memberIds;
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/member/MemberRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/member/MemberRepository.java
@@ -24,7 +24,7 @@ public interface MemberRepository {
 
     MemberProfileResponse getMemberProfile(final long memberId);
 
-    List<MoimMemberResponse> findMembersWithJoinInfo(final List<Long> joinedMoimMemberIds, final long hostId);
+    List<MoimMemberResponse> findMoimMembers(final List<Long> joinedMoimMemberIds, final long hostId, final long moimId);
 
     MemberSimpleResponse getHostProfileByMoimId(final long moimId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/member/MemberRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/member/MemberRepositoryImpl.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import static moim_today.global.constant.exception.MemberExceptionConstant.*;
 import static moim_today.persistence.entity.department.QDepartmentJpaEntity.departmentJpaEntity;
-import static moim_today.persistence.entity.meeting.joined_meeting.QJoinedMeetingJpaEntity.*;
 import static moim_today.persistence.entity.member.QMemberJpaEntity.memberJpaEntity;
 import static moim_today.persistence.entity.moim.joined_moim.QJoinedMoimJpaEntity.joinedMoimJpaEntity;
 import static moim_today.persistence.entity.moim.moim.QMoimJpaEntity.moimJpaEntity;
@@ -92,8 +91,8 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
-    public List<MoimMemberResponse> findMembersWithJoinInfo(final List<Long> joinedMoimMemberIds,
-                                                            final long hostId) {
+    public List<MoimMemberResponse> findMoimMembers(final List<Long> moimMemberIds,
+                                                    final long hostId, final long moimId) {
         return queryFactory.select(new QMoimMemberResponse(
                         memberJpaEntity.id.eq(hostId),
                         memberJpaEntity.id,
@@ -102,7 +101,8 @@ public class MemberRepositoryImpl implements MemberRepository {
                         memberJpaEntity.memberProfileImageUrl
                 )).from(memberJpaEntity)
                 .join(joinedMoimJpaEntity).on(joinedMoimJpaEntity.memberId.eq(memberJpaEntity.id))
-                .where(joinedMoimJpaEntity.memberId.in(joinedMoimMemberIds))
+                .where(joinedMoimJpaEntity.memberId.in(moimMemberIds)
+                        .and(joinedMoimJpaEntity.moimId.eq(moimId)))
                 .fetch();
     }
 

--- a/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/member/MemberFinderTest.java
@@ -3,10 +3,12 @@ package moim_today.implement.member;
 import moim_today.domain.member.enums.Gender;
 import moim_today.dto.member.MemberProfileResponse;
 import moim_today.dto.member.MemberSimpleResponse;
+import moim_today.dto.moim.moim.MoimMemberResponse;
 import moim_today.global.error.BadRequestException;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.department.DepartmentJpaEntity;
 import moim_today.persistence.entity.member.MemberJpaEntity;
+import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.entity.university.UniversityJpaEntity;
 import moim_today.util.ImplementTest;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static moim_today.global.constant.exception.MemberExceptionConstant.*;
 import static moim_today.util.TestConstant.*;
@@ -92,7 +95,7 @@ class MemberFinderTest extends ImplementTest {
         assertThat(memberProfileResponse.email()).isEqualTo(EMAIL.value());
         assertThat(memberProfileResponse.username()).isEqualTo(USERNAME.value());
         assertThat(memberProfileResponse.studentId()).isEqualTo(STUDENT_ID.value());
-        assertThat(memberProfileResponse.birthDate()).isEqualTo(LocalDate.of(2000,12,18));
+        assertThat(memberProfileResponse.birthDate()).isEqualTo(LocalDate.of(2000, 12, 18));
         assertThat(memberProfileResponse.gender()).isEqualTo(Gender.MALE);
         assertThat(memberProfileResponse.memberProfileImageUrl()).isEqualTo(PROFILE_IMAGE_URL.value());
     }
@@ -123,7 +126,7 @@ class MemberFinderTest extends ImplementTest {
 
     @DisplayName("가입한 이메일이 없을 경우 예외가 발생하지 않는다.")
     @Test
-    void notRegisteredEmailTest(){
+    void notRegisteredEmailTest() {
         // expected
         assertThatCode(() -> {
             memberFinder.validateEmailNotExists(EMAIL.value());
@@ -133,7 +136,7 @@ class MemberFinderTest extends ImplementTest {
 
     @DisplayName("모임 생성자의 프로필 정보를 가져온다.")
     @Test
-    void getHostProfileTest(){
+    void getHostProfileTest() {
         // given1
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
                 .username(USERNAME.value())
@@ -162,7 +165,7 @@ class MemberFinderTest extends ImplementTest {
 
     @DisplayName("모임이 없으면 모임 생성자를 조회할 때 예외가 발생한다.")
     @Test
-    void getHostProfileNotExistMoimTest(){
+    void getHostProfileNotExistMoimTest() {
         // given
         long notFoundMoimId = MOIM_ID.longValue();
 
@@ -174,7 +177,7 @@ class MemberFinderTest extends ImplementTest {
 
     @DisplayName("모임이 있어도 생성자가 존재하지 않으면 조회할 때 예외가 발생한다.")
     @Test
-    void getHostProfileNotExistHostTest(){
+    void getHostProfileNotExistHostTest() {
         // given
         MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
                 .memberId(MEMBER_ID.longValue())
@@ -187,5 +190,181 @@ class MemberFinderTest extends ImplementTest {
         assertThatThrownBy(() -> memberFinder.getHostProfileByMoimId(moimId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(HOST_NOT_FOUND_ERROR.message());
+    }
+
+    @DisplayName("모임에 참여한 멤버들의 id를 가지고 멤버 정보를 조회한다")
+    @Test
+    void findMoimMembers() {
+        // given
+        List<String> names = List.of("hostName", "member1", "member2", "member3", "member4");
+
+        MemberJpaEntity host = MemberJpaEntity.builder()
+                .username(names.get(0))
+                .build();
+        MemberJpaEntity moimMember1 = MemberJpaEntity.builder()
+                .username(names.get(1))
+                .build();
+        MemberJpaEntity moimMember2 = MemberJpaEntity.builder()
+                .username(names.get(2))
+                .build();
+        MemberJpaEntity moimMember3 = MemberJpaEntity.builder()
+                .username(names.get(3))
+                .build();
+        MemberJpaEntity moimMember4 = MemberJpaEntity.builder()
+                .username(names.get(4))
+                .build();
+
+        MemberJpaEntity saveHost = memberRepository.save(host);
+        MemberJpaEntity saveMoimMember1 = memberRepository.save(moimMember1);
+        MemberJpaEntity saveMoimMember2 = memberRepository.save(moimMember2);
+        MemberJpaEntity saveMoimMember3 = memberRepository.save(moimMember3);
+        MemberJpaEntity saveMoimMember4 = memberRepository.save(moimMember4);
+
+        List<Long> moimMemberIds = List.of(saveHost.getId(), saveMoimMember1.getId(),
+                saveMoimMember2.getId(), saveMoimMember3.getId(), saveMoimMember4.getId());
+
+        MoimJpaEntity moim = MoimJpaEntity.builder()
+                .memberId(saveHost.getId())
+                .build();
+
+        MoimJpaEntity saveMoim = moimRepository.save(moim);
+
+        JoinedMoimJpaEntity j1 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(host.getId())
+                .build();
+        JoinedMoimJpaEntity j2 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(saveMoimMember1.getId())
+                .build();
+        JoinedMoimJpaEntity j3 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(saveMoimMember2.getId())
+                .build();
+        JoinedMoimJpaEntity j4 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(saveMoimMember3.getId())
+                .build();
+        JoinedMoimJpaEntity j5 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(saveMoimMember4.getId())
+                .build();
+
+        joinedMoimRepository.save(j1);
+        joinedMoimRepository.save(j2);
+        joinedMoimRepository.save(j3);
+        joinedMoimRepository.save(j4);
+        joinedMoimRepository.save(j5);
+
+        // when
+        List<MoimMemberResponse> moimMembers = memberFinder.findMoimMembers(moimMemberIds, saveHost.getId(), saveMoim.getId());
+
+        // then
+        assertThat(moimMembers.size()).isEqualTo(5);
+        moimMembers.forEach(moimMemberResponse -> {
+            assertThat(moimMemberResponse.memberName()).isIn(names);
+        });
+    }
+
+    @DisplayName("다른 모임에 참여한 멤버들을 제외하고 모임의 멤버 정보를 조회한다")
+    @Test
+    void findMoimMembersExcludeAnoterMoimMembers() {
+        // given1
+        List<String> joinNames = List.of("hostName", "member1", "member2");
+        List<String> notJoinNames = List.of("anotherHostName", "member3", "member4");
+
+        MemberJpaEntity host = MemberJpaEntity.builder()
+                .username(joinNames.get(0))
+                .build();
+        MemberJpaEntity moimMember1 = MemberJpaEntity.builder()
+                .username(joinNames.get(1))
+                .build();
+        MemberJpaEntity moimMember2 = MemberJpaEntity.builder()
+                .username(joinNames.get(2))
+                .build();
+
+        MemberJpaEntity saveHost = memberRepository.save(host);
+        MemberJpaEntity saveMoimMember1 = memberRepository.save(moimMember1);
+        MemberJpaEntity saveMoimMember2 = memberRepository.save(moimMember2);
+
+        // given2
+        MemberJpaEntity moimMember3 = MemberJpaEntity.builder()
+                .username(notJoinNames.get(0))
+                .build();
+        MemberJpaEntity moimMember4 = MemberJpaEntity.builder()
+                .username(notJoinNames.get(1))
+                .build();
+        MemberJpaEntity moimMember5 = MemberJpaEntity.builder()
+                .username(notJoinNames.get(2))
+                .build();
+
+        MemberJpaEntity saveAnotherHost = memberRepository.save(moimMember3);
+        MemberJpaEntity saveMoimMember3 = memberRepository.save(moimMember4);
+        MemberJpaEntity saveMoimMember4 = memberRepository.save(moimMember5);
+
+        List<Long> expectMoimMemberIds = List.of(saveHost.getId(), saveMoimMember1.getId(),
+                saveMoimMember2.getId());
+
+        // given3
+        MoimJpaEntity moim = MoimJpaEntity.builder()
+                .memberId(saveHost.getId())
+                .build();
+
+        // given4
+        MoimJpaEntity anotherMoim = MoimJpaEntity.builder()
+                .memberId(saveHost.getId())
+                .build();
+
+        MoimJpaEntity saveMoim = moimRepository.save(moim);
+
+        // given5
+        JoinedMoimJpaEntity j1 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(host.getId())
+                .build();
+        JoinedMoimJpaEntity j2 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(saveMoimMember1.getId())
+                .build();
+        JoinedMoimJpaEntity j3 = JoinedMoimJpaEntity.builder()
+                .moimId(moim.getId())
+                .memberId(saveMoimMember2.getId())
+                .build();
+
+        // given6
+        JoinedMoimJpaEntity j4 = JoinedMoimJpaEntity.builder()
+                .moimId(anotherMoim.getId())
+                .memberId(saveAnotherHost.getId())
+                .build();
+        JoinedMoimJpaEntity j5 = JoinedMoimJpaEntity.builder()
+                .moimId(anotherMoim.getId())
+                .memberId(saveMoimMember3.getId())
+                .build();
+        JoinedMoimJpaEntity j6 = JoinedMoimJpaEntity.builder()
+                .moimId(anotherMoim.getId())
+                .memberId(saveMoimMember4.getId())
+                .build();
+        JoinedMoimJpaEntity j7 = JoinedMoimJpaEntity.builder()
+                .moimId(anotherMoim.getId())
+                .memberId(saveMoimMember1.getId())
+                .build();
+
+        joinedMoimRepository.save(j1);
+        joinedMoimRepository.save(j2);
+        joinedMoimRepository.save(j3);
+        joinedMoimRepository.save(j4);
+        joinedMoimRepository.save(j5);
+        joinedMoimRepository.save(j6);
+        joinedMoimRepository.save(j7);
+
+        // when
+        List<MoimMemberResponse> moimMembers = memberFinder.findMoimMembers(expectMoimMemberIds, saveHost.getId(), saveMoim.getId());
+
+        // then
+        assertThat(moimMembers.size()).isEqualTo(3);
+        moimMembers.forEach(moimMemberResponse -> {
+            assertThat(moimMemberResponse.memberName()).isIn(joinNames);
+            assertThat(moimMemberResponse.memberId()).isIn(expectMoimMemberIds);
+        });
     }
 }

--- a/backend/src/test/java/moim_today/implement/moim/joined_moim/JoinedMoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/joined_moim/JoinedMoimFinderTest.java
@@ -52,6 +52,47 @@ class JoinedMoimFinderTest extends ImplementTest {
         assertThat(membersByMoimId.size()).isEqualTo(MOIM_MEMBER_SIZE);
     }
 
+    @DisplayName("모임에 참여한 멤버들을 조회할 때 다른 모임의 멤버는 조회하지 않는다")
+    @Test
+    void findMembersByMoimIdExcludeAnotherMoimMembers() {
+
+        // given1
+        MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
+                .memberId(1L)
+                .build();
+
+        MoimJpaEntity moimJpaEntity2 = MoimJpaEntity.builder()
+                .memberId(2L)
+                .build();
+
+        MoimJpaEntity savedMoim1 = moimRepository.save(moimJpaEntity1);
+        MoimJpaEntity savedMoim2 = moimRepository.save(moimJpaEntity2);
+
+        // given2
+        for(int i  = 0 ; i < MOIM_MEMBER_SIZE; i++){
+            JoinedMoimJpaEntity joinedMoimJpaEntity = JoinedMoimJpaEntity.builder()
+                    .memberId(i)
+                    .moimId(savedMoim1.getId())
+                    .build();
+            joinedMoimRepository.save(joinedMoimJpaEntity);
+        }
+
+        for(int i  = 0 ; i < MOIM_MEMBER_SIZE; i++){
+            JoinedMoimJpaEntity joinedMoimJpaEntity = JoinedMoimJpaEntity.builder()
+                    .memberId(i)
+                    .moimId(savedMoim2.getId())
+                    .build();
+            joinedMoimRepository.save(joinedMoimJpaEntity);
+        }
+
+
+        // when
+        List<JoinedMoimJpaEntity> membersByMoimId = joinedMoimFinder.findByMoimId(savedMoim1.getId());
+
+        // then
+        assertThat(membersByMoimId.size()).isEqualTo(MOIM_MEMBER_SIZE);
+    }
+
     @DisplayName("모임의 멤버를 조회할 때 아무도 없으면 에러를 발생시킨다")
     @Test
     void findMembersByMoimIdNotFound() {

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
@@ -113,11 +113,13 @@ class MoimFinderTest extends ImplementTest {
         joinedMoimJpaEntities.add(saveJoinedMoim(savedMoim.getId(), savedMember2.getId()));
         joinedMoimJpaEntities.add(saveJoinedMoim(savedMoim.getId(), savedMember3.getId()));
 
+        List<Long> memberIds = JoinedMoimJpaEntity.extractMemberIds(joinedMoimJpaEntities);
         // when
-        List<MoimMemberResponse> moimMembers = moimFinder.findMembersInMoim(joinedMoimJpaEntities, savedMoim.getMemberId());
+        List<MoimMemberResponse> moimMembers = moimFinder.findMembersInMoim(memberIds,
+                savedMoim.getMemberId(), savedMoim.getId());
 
         List<Long> moimMemberIds = new ArrayList<>();
-        moimMembers.stream().forEach(m -> moimMemberIds.add(m.memberId()));
+        moimMembers.forEach(m -> moimMemberIds.add(m.memberId()));
 
         // then
         assertThat(moimMembers.size()).isEqualTo(MOIM_MEMBER_SIZE);


### PR DESCRIPTION
## 📝작업 내용

모임에 참여한 멤버 정보를 조회할 때, 모임 id에 관한 조건절 추가,
다른 모임에 참여한 동일 멤버의 정보를 안 가져오도록 수정

