### PR TITLE
[BE] 모임 공지 리스트 조회시 잘못된 캐시값 문제 수정

### DIFF
--- a/backend/src/main/java/moim_today/application/moim/moim_notice/MoimNoticeServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim_notice/MoimNoticeServiceImpl.java
@@ -36,7 +36,7 @@ public class MoimNoticeServiceImpl implements MoimNoticeService{
 
     @Override
     public void createMoimNotice(final long memberId, final MoimNoticeCreateRequest moimNoticeCreateRequest) {
-        moimNoticeAppender.createMoimNotice(memberId, moimNoticeCreateRequest);
+        moimNoticeAppender.createMoimNotice(memberId, moimNoticeCreateRequest.moimId(), moimNoticeCreateRequest);
     }
 
     @Override

--- a/backend/src/main/java/moim_today/implement/moim/moim_notice/MoimNoticeAppender.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim_notice/MoimNoticeAppender.java
@@ -6,6 +6,7 @@ import moim_today.implement.moim.moim.MoimFinder;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.entity.moim.moim_notice.MoimNoticeJpaEntity;
 import moim_today.persistence.repository.moim.moim_notice.MoimNoticeRepository;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 @Implement
@@ -20,9 +21,10 @@ public class MoimNoticeAppender {
         this.moimFinder = moimFinder;
     }
 
+    @CacheEvict(value = "moimNotices", key = "#moimId")
     @Transactional
-    public void createMoimNotice(final long memberId, final MoimNoticeCreateRequest moimNoticeCreateRequest) {
-        MoimJpaEntity moimJpaEntity = moimFinder.getById(moimNoticeCreateRequest.moimId());
+    public void createMoimNotice(final long memberId, final long moimId, final MoimNoticeCreateRequest moimNoticeCreateRequest) {
+        MoimJpaEntity moimJpaEntity = moimFinder.getById(moimId);
         moimJpaEntity.validateHostMember(memberId);
         MoimNoticeJpaEntity moimNoticeJpaEntity = moimNoticeCreateRequest.toEntity();
         moimNoticeRepository.save(moimNoticeJpaEntity);

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
@@ -203,7 +203,7 @@ class MoimFinderTest extends ImplementTest {
 
     @DisplayName("필터가 없으면 모든 카테고리의 모임 리스트를 최신 생성 순으로 가져온다.")
     @Test
-    void findAllMoim() {
+    void findAllMoim() throws InterruptedException {
         // given
         MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
                 .title(FIRST_CREATED_MOIM_TITLE.value())
@@ -211,6 +211,8 @@ class MoimFinderTest extends ImplementTest {
                 .build();
 
         moimRepository.save(firstCreatedMoimJpaEntity);
+
+        Thread.sleep(10);
 
         MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
                 .title(SECOND_CREATED_MOIM_TITLE.value())
@@ -233,7 +235,7 @@ class MoimFinderTest extends ImplementTest {
 
     @DisplayName("모임 리스트를 최신 생성 순으로 가져온다.")
     @Test
-    void findAllMoimOrderByCreatedAt() {
+    void findAllMoimOrderByCreatedAt() throws InterruptedException {
         // given
         MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
                 .title(FIRST_CREATED_MOIM_TITLE.value())
@@ -241,6 +243,8 @@ class MoimFinderTest extends ImplementTest {
                 .build();
 
         moimRepository.save(firstCreatedMoimJpaEntity);
+
+        Thread.sleep(10);
 
         MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
                 .title(SECOND_CREATED_MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/implement/moim/moim_notice/MoimNoticeAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim_notice/MoimNoticeAppenderTest.java
@@ -3,11 +3,18 @@ package moim_today.implement.moim.moim_notice;
 import moim_today.dto.moim.moim_notice.MoimNoticeCreateRequest;
 import moim_today.global.error.ForbiddenException;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
+import moim_today.persistence.entity.moim.moim_notice.MoimNoticeJpaEntity;
 import moim_today.util.ImplementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 import static moim_today.global.constant.exception.MoimExceptionConstant.ORGANIZER_FORBIDDEN_ERROR;
 import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.*;
@@ -17,16 +24,22 @@ class MoimNoticeAppenderTest extends ImplementTest {
     @Autowired
     private MoimNoticeAppender moimNoticeAppender;
 
+    @Autowired
+    private MoimNoticeFinder moimNoticeFinder;
+
+    @Autowired
+    private CacheManager cacheManager;
+
     @DisplayName("공지를 생성한다.")
     @Test
     void createNoticeTest() {
         //given
-        MoimJpaEntity owner = MoimJpaEntity.builder()
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
                 .memberId(MEMBER_ID.longValue())
                 .build();
 
-        moimRepository.save(owner);
-        long moimId = owner.getId();
+        moimRepository.save(moimJpaEntity);
+        long moimId = moimJpaEntity.getId();
 
         MoimNoticeCreateRequest moimNoticeCreateRequest = new MoimNoticeCreateRequest(
                 moimId,
@@ -35,7 +48,7 @@ class MoimNoticeAppenderTest extends ImplementTest {
         );
 
         //when
-        assertThatCode(() -> moimNoticeAppender.createMoimNotice(MEMBER_ID.longValue(), moimNoticeCreateRequest))
+        assertThatCode(() -> moimNoticeAppender.createMoimNotice(MEMBER_ID.longValue(), moimNoticeCreateRequest.moimId(), moimNoticeCreateRequest))
                 .doesNotThrowAnyException();
 
         //then
@@ -63,8 +76,41 @@ class MoimNoticeAppenderTest extends ImplementTest {
         );
 
         //expected
-        assertThatThrownBy(() -> moimNoticeAppender.createMoimNotice(forbiddenMemberId, moimNoticeCreateRequest))
+        assertThatThrownBy(() -> moimNoticeAppender.createMoimNotice(forbiddenMemberId, moimNoticeCreateRequest.moimId(), moimNoticeCreateRequest))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage(ORGANIZER_FORBIDDEN_ERROR.message());
+    }
+
+    @DisplayName("모임 공지를 새로 생성하면 공지 리스트 캐시를 삭제한다.")
+    @Test
+    void createNoticeDeleteCacheTest() {
+        //given1
+        long memberId = MEMBER_ID.longValue();
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .memberId(memberId)
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+        long moimId = moimJpaEntity.getId();
+
+        //caching1
+        moimNoticeFinder.findAllMoimNotice(moimId);
+
+        //given2
+        MoimNoticeCreateRequest moimNoticeCreateRequest = new MoimNoticeCreateRequest(
+                moimId,
+                NOTICE_TITLE.value(),
+                NOTICE_CONTENTS.value()
+        );
+
+        //when
+        moimNoticeAppender.createMoimNotice(memberId, moimId, moimNoticeCreateRequest);
+        moimNoticeFinder.findAllMoimNotice(moimId);
+
+        //then
+        Object noticesCacheObject = requireNonNull(cacheManager.getCache("moimNotices")).get(moimId, Object.class);
+        assert noticesCacheObject != null;
+        List<?> noticesList = (List<?>) noticesCacheObject;
+        assertThat(noticesList.size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 모임 "홈"페이지에서 공지 리스트 조회시 빈 리스트가 반환되어 캐시되는 문제가 있어서, 공지를 생성했을 때, 공지리스트 조회 시 캐시된 빈 리스트가 반환되는 문제를 해결함
> 모임 생성시 캐시된 공지리스트 삭제
> 테스트
