### PR TITLE
[BE] 모임 리스트 조회, 모임 검색시 같은 대학 모임만 조회 

### DIFF
--- a/backend/src/main/java/moim_today/application/meeting/meeting/MeetingService.java
+++ b/backend/src/main/java/moim_today/application/meeting/meeting/MeetingService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface MeetingService {
 
-    MeetingCreateResponse createMeeting(final MeetingCreateRequest meetingCreateRequest);
+    MeetingCreateResponse createMeeting(final long memberId, final MeetingCreateRequest meetingCreateRequest);
 
     List<MeetingSimpleResponse> findAllByMoimId(final long moimId, final long memberId, final MeetingStatus meetingStatus);
 

--- a/backend/src/main/java/moim_today/application/meeting/meeting/MeetingServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/meeting/meeting/MeetingServiceImpl.java
@@ -30,8 +30,8 @@ public class MeetingServiceImpl implements MeetingService {
     }
 
     @Override
-    public MeetingCreateResponse createMeeting(final MeetingCreateRequest meetingCreateRequest) {
-        return meetingManager.createMeeting(meetingCreateRequest, LocalDate.now());
+    public MeetingCreateResponse createMeeting(final long memberId, final MeetingCreateRequest meetingCreateRequest) {
+        return meetingManager.createMeeting(memberId, meetingCreateRequest, LocalDate.now());
     }
 
     @Override

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
@@ -31,7 +31,7 @@ public interface MoimService {
 
     void appendMemberToMoim(final long requestMemberId, final MoimJoinRequest moimJoinRequest);
 
-    List<MoimSimpleResponse> findAllMoimResponse(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
+    List<MoimSimpleResponse> findAllMoimResponses(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
 
-    List<MoimSimpleResponse> searchMoim(final String searchParam);
+    List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam);
 }

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
@@ -31,7 +31,7 @@ public interface MoimService {
 
     void appendMemberToMoim(final long requestMemberId, final MoimJoinRequest moimJoinRequest);
 
-    List<MoimSimpleResponse> findAllMoimResponse(final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
+    List<MoimSimpleResponse> findAllMoimResponse(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
 
     List<MoimSimpleResponse> searchMoim(final String searchParam);
 }

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -160,8 +160,12 @@ public class MoimServiceImpl implements MoimService{
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMoimResponse(final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
-        return moimFinder.findAllMoimResponse(moimCategoryDto, moimSortedFilter);
+    public List<MoimSimpleResponse> findAllMoimResponse(
+            final long universityId,
+            final MoimCategoryDto moimCategoryDto,
+            final MoimSortedFilter moimSortedFilter) {
+
+        return moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
     }
 
     @Override

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -160,16 +160,16 @@ public class MoimServiceImpl implements MoimService{
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMoimResponse(
+    public List<MoimSimpleResponse> findAllMoimResponses(
             final long universityId,
             final MoimCategoryDto moimCategoryDto,
             final MoimSortedFilter moimSortedFilter) {
 
-        return moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+        return moimFinder.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
     }
 
     @Override
-    public List<MoimSimpleResponse> searchMoim(final String searchParam) {
-        return moimFinder.searchMoim(searchParam);
+    public List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam) {
+        return moimFinder.searchMoim(universityId, searchParam);
     }
 }

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimAppender.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimAppender.java
@@ -2,7 +2,6 @@ package moim_today.implement.moim.moim;
 
 import moim_today.dto.moim.moim.MoimCreateRequest;
 import moim_today.global.annotation.Implement;
-import moim_today.implement.moim.joined_moim.JoinedMoimAppender;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,12 +11,9 @@ public class MoimAppender {
 
     private final MoimRepository moimRepository;
 
-    private final JoinedMoimAppender joinedMoimAppender;
 
-    public MoimAppender(final MoimRepository moimRepository,
-                        final JoinedMoimAppender joinedMoimAppender) {
+    public MoimAppender(final MoimRepository moimRepository) {
         this.moimRepository = moimRepository;
-        this.joinedMoimAppender = joinedMoimAppender;
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
@@ -73,8 +73,8 @@ public class MoimFinder {
     }
 
     @Transactional(readOnly = true)
-    public List<MoimSimpleResponse> findAllMoimResponse(final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
-        return moimRepository.findAllMoimResponse(moimCategoryDto, moimSortedFilter);
+    public List<MoimSimpleResponse> findAllMoimResponseByUniversityId(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
+        return moimRepository.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
@@ -15,7 +15,6 @@ import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static moim_today.global.constant.exception.MoimExceptionConstant.MOIM_CAPACITY_ERROR;
@@ -73,8 +72,8 @@ public class MoimFinder {
     }
 
     @Transactional(readOnly = true)
-    public List<MoimSimpleResponse> findAllMoimResponseByUniversityId(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
-        return moimRepository.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+    public List<MoimSimpleResponse> findAllMoimResponses(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
+        return moimRepository.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
     }
 
     @Transactional(readOnly = true)
@@ -94,13 +93,7 @@ public class MoimFinder {
     }
 
     @Transactional(readOnly = true)
-    public List<MoimSimpleResponse> searchMoim(final String searchParam) {
-        return moimRepository.searchMoimBySearchParam(searchParam);
-    }
-
-    private List<Long> extractMemberIds(final List<JoinedMoimJpaEntity> joinedMoimJpaEntities) {
-        List<Long> memberIds = new ArrayList<>();
-        joinedMoimJpaEntities.forEach(e -> memberIds.add(e.getMemberId()));
-        return memberIds;
+    public List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam) {
+        return moimRepository.searchMoimBySearchParam(universityId, searchParam);
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepository.java
@@ -23,11 +23,11 @@ public interface MoimRepository {
 
     void deleteById(final long moimId);
 
-    List<MoimSimpleResponse> findAllMoimResponseByUniversityId(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
+    List<MoimSimpleResponse> findAllMoimResponses(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
 
     List<MyMoimResponse> findAllMyMoimResponse(final List<Long> moimIds);
 
     MoimJpaEntity getByIdWithPessimisticLock(final long moimId);
 
-    List<MoimSimpleResponse> searchMoimBySearchParam(final String searchParam);
+    List<MoimSimpleResponse> searchMoimBySearchParam(final long universityId, final String searchParam);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepository.java
@@ -23,7 +23,7 @@ public interface MoimRepository {
 
     void deleteById(final long moimId);
 
-    List<MoimSimpleResponse> findAllMoimResponse(final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
+    List<MoimSimpleResponse> findAllMoimResponseByUniversityId(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
 
     List<MyMoimResponse> findAllMyMoimResponse(final List<Long> moimIds);
 

--- a/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepositoryImpl.java
@@ -10,13 +10,11 @@ import moim_today.dto.moim.moim.*;
 import moim_today.dto.moim.moim.enums.MoimCategoryDto;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
-import moim_today.persistence.entity.moim.moim.QMoimJpaEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 import java.util.List;
+import java.util.Optional;
 
 import static moim_today.global.constant.SymbolConstant.PERCENT;
 import static moim_today.global.constant.exception.MoimExceptionConstant.MOIM_NOT_FOUND_ERROR;
@@ -87,7 +85,7 @@ public class MoimRepositoryImpl implements MoimRepository {
     }
 
     @Override
-    public List<MoimSimpleResponse> searchMoimBySearchParam(final String searchParam) {
+    public List<MoimSimpleResponse> searchMoimBySearchParam(final long universityId, final String searchParam) {
         return queryFactory.select(new QMoimSimpleResponse(
                         moimJpaEntity.id,
                         moimJpaEntity.title,
@@ -98,14 +96,16 @@ public class MoimRepositoryImpl implements MoimRepository {
                         moimJpaEntity.displayStatus
                 ))
                 .from(moimJpaEntity)
-                .where(moimJpaEntity.title.likeIgnoreCase(PERCENT.value() + searchParam.trim() + PERCENT.value()))
+                .where(moimJpaEntity.universityId.eq(universityId)
+                        .and(moimJpaEntity.title.likeIgnoreCase(PERCENT.value() + searchParam.trim() + PERCENT.value()))
+                )
                 .fetch();
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMoimResponseByUniversityId(final long universityId,
-                                                                      final MoimCategoryDto moimCategoryDto,
-                                                                      final MoimSortedFilter moimSortedFilter) {
+    public List<MoimSimpleResponse> findAllMoimResponses(final long universityId,
+                                                         final MoimCategoryDto moimCategoryDto,
+                                                         final MoimSortedFilter moimSortedFilter) {
 
         return queryFactory.select(new QMoimSimpleResponse(
                         moimJpaEntity.id,
@@ -117,7 +117,9 @@ public class MoimRepositoryImpl implements MoimRepository {
                         moimJpaEntity.displayStatus
                 ))
                 .from(moimJpaEntity)
-                .where(moimJpaEntity.universityId.eq(universityId).and(applyMoimCategoryFilter(moimCategoryDto)))
+                .where(moimJpaEntity.universityId.eq(universityId)
+                        .and(applyMoimCategoryFilter(moimCategoryDto))
+                )
                 .orderBy(createOrderBySpecifier(moimSortedFilter))
                 .fetch();
     }

--- a/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepositoryImpl.java
@@ -103,7 +103,9 @@ public class MoimRepositoryImpl implements MoimRepository {
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMoimResponse(final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
+    public List<MoimSimpleResponse> findAllMoimResponseByUniversityId(final long universityId,
+                                                                      final MoimCategoryDto moimCategoryDto,
+                                                                      final MoimSortedFilter moimSortedFilter) {
 
         return queryFactory.select(new QMoimSimpleResponse(
                         moimJpaEntity.id,
@@ -115,7 +117,7 @@ public class MoimRepositoryImpl implements MoimRepository {
                         moimJpaEntity.displayStatus
                 ))
                 .from(moimJpaEntity)
-                .where(applyMoimCategoryFilter(moimCategoryDto))
+                .where(moimJpaEntity.universityId.eq(universityId).and(applyMoimCategoryFilter(moimCategoryDto)))
                 .orderBy(createOrderBySpecifier(moimSortedFilter))
                 .fetch();
     }

--- a/backend/src/main/java/moim_today/presentation/meeting/meeting/MeetingController.java
+++ b/backend/src/main/java/moim_today/presentation/meeting/meeting/MeetingController.java
@@ -25,8 +25,10 @@ public class MeetingController {
     }
 
     @PostMapping
-    public MeetingCreateResponse createMeeting(@RequestBody final MeetingCreateRequest meetingCreateRequest) {
-        return meetingService.createMeeting(meetingCreateRequest);
+    public MeetingCreateResponse createMeeting(
+            @Login final MemberSession memberSession,
+            @RequestBody final MeetingCreateRequest meetingCreateRequest) {
+        return meetingService.createMeeting(memberSession.id(), meetingCreateRequest);
     }
 
     @GetMapping("/{moimId}")

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -56,7 +56,7 @@ public class MoimController {
     }
 
     @GetMapping("/simple")
-    public CollectionResponse<List<MoimSimpleResponse>> findAllMoimResponse(
+    public CollectionResponse<List<MoimSimpleResponse>> findAllMoimResponses(
             @Login final MemberSession memberSession,
             @RequestParam final MoimCategoryDto moimCategoryDto,
             @RequestParam final MoimSortedFilter moimSortedFilter) {
@@ -130,8 +130,10 @@ public class MoimController {
     }
 
     @GetMapping("/search")
-    public CollectionResponse<List<MoimSimpleResponse>> searchMoim(@RequestParam final String searchParam) {
-        return CollectionResponse.from(moimService.searchMoim(searchParam));
+    public CollectionResponse<List<MoimSimpleResponse>> searchMoim(
+            @Login final MemberSession memberSession,
+            @RequestParam final String searchParam) {
+        return CollectionResponse.from(moimService.searchMoim(memberSession.universityId(), searchParam));
     }
 
     @GetMapping("/categories")

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -60,7 +60,7 @@ public class MoimController {
             @Login final MemberSession memberSession,
             @RequestParam final MoimCategoryDto moimCategoryDto,
             @RequestParam final MoimSortedFilter moimSortedFilter) {
-        return CollectionResponse.from(moimService.findAllMoimResponse(memberSession.universityId(), moimCategoryDto, moimSortedFilter));
+        return CollectionResponse.from(moimService.findAllMoimResponses(memberSession.universityId(), moimCategoryDto, moimSortedFilter));
     }
 
     @PatchMapping

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -56,9 +56,11 @@ public class MoimController {
     }
 
     @GetMapping("/simple")
-    public CollectionResponse<List<MoimSimpleResponse>> findAllMoimResponse(@RequestParam final MoimCategoryDto moimCategoryDto,
-                                                                            @RequestParam final MoimSortedFilter moimSortedFilter) {
-        return CollectionResponse.from(moimService.findAllMoimResponse(moimCategoryDto, moimSortedFilter));
+    public CollectionResponse<List<MoimSimpleResponse>> findAllMoimResponse(
+            @Login final MemberSession memberSession,
+            @RequestParam final MoimCategoryDto moimCategoryDto,
+            @RequestParam final MoimSortedFilter moimSortedFilter) {
+        return CollectionResponse.from(moimService.findAllMoimResponse(memberSession.universityId(), moimCategoryDto, moimSortedFilter));
     }
 
     @PatchMapping

--- a/backend/src/test/java/moim_today/fake_class/meeting/meeting/FakeMeetingService.java
+++ b/backend/src/test/java/moim_today/fake_class/meeting/meeting/FakeMeetingService.java
@@ -19,7 +19,7 @@ import static moim_today.util.TestConstant.*;
 public class FakeMeetingService implements MeetingService {
 
     @Override
-    public MeetingCreateResponse createMeeting(final MeetingCreateRequest meetingCreateRequest) {
+    public MeetingCreateResponse createMeeting(final long memberId, final MeetingCreateRequest meetingCreateRequest) {
         return MeetingCreateResponse.of(MEETING_ID.longValue(), meetingCreateRequest);
     }
 

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -146,7 +146,9 @@ public class FakeMoimService implements MoimService {
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMoimResponse(final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter) {
+    public List<MoimSimpleResponse> findAllMoimResponse(final long universityId,
+                                                        final MoimCategoryDto moimCategoryDto,
+                                                        final MoimSortedFilter moimSortedFilter) {
         MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -146,9 +146,9 @@ public class FakeMoimService implements MoimService {
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMoimResponse(final long universityId,
-                                                        final MoimCategoryDto moimCategoryDto,
-                                                        final MoimSortedFilter moimSortedFilter) {
+    public List<MoimSimpleResponse> findAllMoimResponses(final long universityId,
+                                                         final MoimCategoryDto moimCategoryDto,
+                                                         final MoimSortedFilter moimSortedFilter) {
         MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())
@@ -173,7 +173,7 @@ public class FakeMoimService implements MoimService {
     }
 
     @Override
-    public List<MoimSimpleResponse> searchMoim(final String searchParam) {
+    public List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam) {
         MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
@@ -3,6 +3,7 @@ package moim_today.implement.meeting.meeting;
 import moim_today.domain.meeting.enums.MeetingCategory;
 import moim_today.dto.meeting.MeetingCreateResponse;
 import moim_today.dto.meeting.meeting.MeetingCreateRequest;
+import moim_today.persistence.entity.member.MemberJpaEntity;
 import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
@@ -27,8 +28,16 @@ class MeetingManagerTest extends ImplementTest {
     @Test
     void createSingleMeeting() {
         // given 1
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
+
+        // given 2
         MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
                 .title(MOIM_TITLE.value())
+                .memberId(memberId)
                 .build();
 
         moimRepository.save(moimJpaEntity);
@@ -47,7 +56,7 @@ class MeetingManagerTest extends ImplementTest {
         LocalDate currentDate = LocalDate.of(2024, 3, 4);
 
         // when
-        MeetingCreateResponse meetingCreateResponse = meetingManager.createMeeting(meetingCreateRequest, currentDate);
+        MeetingCreateResponse meetingCreateResponse = meetingManager.createMeeting(memberId, meetingCreateRequest, currentDate);
 
         // then
         assertThat(meetingRepository.count()).isEqualTo(1);
@@ -102,7 +111,11 @@ class MeetingManagerTest extends ImplementTest {
     @Test
     void createRegularMeetingFromStartDate() {
         // given 1
-        long memberId = 1;
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
         LocalDate currentDate = LocalDate.of(2024, 2, 1);
         LocalDate startDate = LocalDate.of(2024, 3, 4);
         LocalDate endDate = LocalDate.of(2024, 6, 30);
@@ -126,7 +139,7 @@ class MeetingManagerTest extends ImplementTest {
                 .build();
 
         // when
-        MeetingCreateResponse meetingCreateResponse = meetingManager.createMeeting(meetingCreateRequest, currentDate);
+        MeetingCreateResponse meetingCreateResponse = meetingManager.createMeeting(memberId, meetingCreateRequest, currentDate);
 
         // then
         long between = ChronoUnit.WEEKS.between(startDate, endDate) + 1;
@@ -142,7 +155,11 @@ class MeetingManagerTest extends ImplementTest {
     @Test
     void createSingleMeetingWithJoinedAndSchedule() {
         // given 1
-        long memberId = 1;
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
         LocalDate currentDate = LocalDate.of(2024, 3, 30);
         LocalDate startDate = LocalDate.of(2024, 3, 4);
         LocalDate endDate = LocalDate.of(2024, 6, 30);
@@ -176,7 +193,7 @@ class MeetingManagerTest extends ImplementTest {
                 .build();
 
         // when
-        meetingManager.createMeeting(meetingCreateRequest, currentDate);
+        meetingManager.createMeeting(memberId, meetingCreateRequest, currentDate);
 
         // then
         assertThat(meetingRepository.count()).isEqualTo(1);
@@ -188,7 +205,11 @@ class MeetingManagerTest extends ImplementTest {
     @Test
     void createRegularMeetingWithJoinedAndSchedule() {
         // given 1
-        long memberId = 1;
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
         LocalDate currentDate = LocalDate.of(2024, 3, 30);
         LocalDate startDate = LocalDate.of(2024, 3, 4);
         LocalDate endDate = LocalDate.of(2024, 6, 30);
@@ -222,7 +243,7 @@ class MeetingManagerTest extends ImplementTest {
                 .build();
 
         // when
-        meetingManager.createMeeting(meetingCreateRequest, currentDate);
+        meetingManager.createMeeting(memberId, meetingCreateRequest, currentDate);
 
         // then
         long between = ChronoUnit.WEEKS.between(currentDate, endDate) + 1;
@@ -235,7 +256,11 @@ class MeetingManagerTest extends ImplementTest {
     @Test
     void createMeetingScheduleIfNotExist() {
         // given 1
-        long memberId = 1;
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+        long memberId = memberJpaEntity.getId();
         LocalDate currentDate = LocalDate.of(2024, 3, 30);
         LocalDate startDate = LocalDate.of(2024, 3, 4);
         LocalDate endDate = LocalDate.of(2024, 6, 30);
@@ -276,7 +301,7 @@ class MeetingManagerTest extends ImplementTest {
                 .build();
 
         // when
-        meetingManager.createMeeting(meetingCreateRequest, currentDate);
+        meetingManager.createMeeting(memberId, meetingCreateRequest, currentDate);
 
         // then
         assertThat(meetingRepository.count()).isEqualTo(1);

--- a/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
@@ -95,7 +95,7 @@ class MeetingManagerTest extends ImplementTest {
                 .build();
 
         // when
-        MeetingCreateResponse meetingCreateResponse = meetingManager.createMeeting(meetingCreateRequest, currentDate);
+        MeetingCreateResponse meetingCreateResponse = meetingManager.createMeeting(memberId, meetingCreateRequest, currentDate);
 
         // then
         long between = ChronoUnit.WEEKS.between(currentDate, endDate) + 1;

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
@@ -13,8 +13,6 @@ import moim_today.persistence.entity.member.MemberJpaEntity;
 import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.util.ImplementTest;
-import moim_today.util.TestConstant;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -250,7 +248,10 @@ class MoimFinderTest extends ImplementTest {
     @Test
     void findAllMoim() throws InterruptedException {
         // given
+        long universityId = UNIV_ID.longValue();
+
         MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(FIRST_CREATED_MOIM_TITLE.value())
                 .moimCategory(MoimCategory.TEAM_PROJECT)
                 .build();
@@ -262,6 +263,7 @@ class MoimFinderTest extends ImplementTest {
         Thread.sleep(10);
 
         MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(SECOND_CREATED_MOIM_TITLE.value())
                 .moimCategory(MoimCategory.STUDY)
                 .build();
@@ -272,7 +274,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = null;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponse(moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(2);
@@ -284,7 +286,10 @@ class MoimFinderTest extends ImplementTest {
     @Test
     void findAllMoimOrderByCreatedAt() throws InterruptedException {
         // given
+        long universityId = UNIV_ID.longValue();
+
         MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(FIRST_CREATED_MOIM_TITLE.value())
                 .moimCategory(MoimCategory.TEAM_PROJECT)
                 .build();
@@ -296,6 +301,7 @@ class MoimFinderTest extends ImplementTest {
         Thread.sleep(10);
 
         MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(SECOND_CREATED_MOIM_TITLE.value())
                 .moimCategory(MoimCategory.STUDY)
                 .build();
@@ -306,7 +312,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = MoimSortedFilter.CREATED_AT;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponse(moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(2);
@@ -318,7 +324,10 @@ class MoimFinderTest extends ImplementTest {
     @Test
     void findAllMoimOrderByViews() {
         // given
+        long universityId = UNIV_ID.longValue();
+
         MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(FIRST_CREATED_MOIM_TITLE.value())
                 .views(10)
                 .build();
@@ -326,6 +335,7 @@ class MoimFinderTest extends ImplementTest {
         moimRepository.save(firstCreatedMoimJpaEntity);
 
         MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(SECOND_CREATED_MOIM_TITLE.value())
                 .views(20)
                 .build();
@@ -336,7 +346,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = MoimSortedFilter.VIEWS;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponse(moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(2);
@@ -348,7 +358,10 @@ class MoimFinderTest extends ImplementTest {
     @Test
     void findAllMoimByCategory() {
         // given
+        long universityId = UNIV_ID.longValue();
+
         MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(FIRST_CREATED_MOIM_TITLE.value())
                 .moimCategory(MoimCategory.TEAM_PROJECT)
                 .build();
@@ -356,6 +369,7 @@ class MoimFinderTest extends ImplementTest {
         moimRepository.save(firstCreatedMoimJpaEntity);
 
         MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(SECOND_CREATED_MOIM_TITLE.value())
                 .moimCategory(MoimCategory.STUDY)
                 .build();
@@ -366,7 +380,41 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = null;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponse(moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+
+        // then
+        assertThat(moimSimpleResponses.size()).isEqualTo(1);
+        assertThat(moimSimpleResponses.get(0).title()).isEqualTo(FIRST_CREATED_MOIM_TITLE.value());
+    }
+
+    @DisplayName("자신이 속한 대학교의 모임리스트만 가져온다.")
+    @Test
+    void findAllMoimByCategoryByUniversityId() {
+        // given
+        long universityId = UNIV_ID.longValue();
+        long otherUniversityId = UNIV_ID.longValue() + 1;
+
+        MoimJpaEntity firstCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
+                .title(FIRST_CREATED_MOIM_TITLE.value())
+                .moimCategory(MoimCategory.TEAM_PROJECT)
+                .build();
+
+        moimRepository.save(firstCreatedMoimJpaEntity);
+
+        MoimJpaEntity secondCreatedMoimJpaEntity = MoimJpaEntity.builder()
+                .universityId(otherUniversityId)
+                .title(SECOND_CREATED_MOIM_TITLE.value())
+                .moimCategory(MoimCategory.STUDY)
+                .build();
+
+        moimRepository.save(secondCreatedMoimJpaEntity);
+
+        MoimCategoryDto moimCategoryDto = MoimCategoryDto.ALL;
+        MoimSortedFilter moimSortedFilter = null;
+
+        // when
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(1);

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
@@ -274,7 +274,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = null;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(2);
@@ -312,7 +312,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = MoimSortedFilter.CREATED_AT;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(2);
@@ -346,7 +346,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = MoimSortedFilter.VIEWS;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(2);
@@ -380,7 +380,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = null;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(1);
@@ -414,7 +414,7 @@ class MoimFinderTest extends ImplementTest {
         MoimSortedFilter moimSortedFilter = null;
 
         // when
-        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponseByUniversityId(universityId, moimCategoryDto, moimSortedFilter);
+        List<MoimSimpleResponse> moimSimpleResponses = moimFinder.findAllMoimResponses(universityId, moimCategoryDto, moimSortedFilter);
 
         // then
         assertThat(moimSimpleResponses.size()).isEqualTo(1);
@@ -525,17 +525,22 @@ class MoimFinderTest extends ImplementTest {
     @Test
     void searchMoimBySearchParam() {
         // given1
+        long universityId = UNIV_ID.longValue();
+
         MoimJpaEntity moimA = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title("appleMango")
                 .build();
 
         // given2
         MoimJpaEntity moimB = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title(" " + "apple" + " " + "mango" + " ")
                 .build();
 
         // given3
         MoimJpaEntity moimC = MoimJpaEntity.builder()
+                .universityId(universityId)
                 .title("apple" + " " + "mango")
                 .build();
 
@@ -544,11 +549,11 @@ class MoimFinderTest extends ImplementTest {
         moimRepository.save(moimC);
 
         //when
-        List<MoimSimpleResponse> appleResponses = moimFinder.searchMoim("apple");
-        List<MoimSimpleResponse> mangoResponses = moimFinder.searchMoim("mango");
-        List<MoimSimpleResponse> blankResponses = moimFinder.searchMoim(" ");
-        List<MoimSimpleResponse> noneResponses = moimFinder.searchMoim("none");
-        List<MoimSimpleResponse> applemangoResponses = moimFinder.searchMoim("apple mango");
+        List<MoimSimpleResponse> appleResponses = moimFinder.searchMoim(universityId, "apple");
+        List<MoimSimpleResponse> mangoResponses = moimFinder.searchMoim(universityId, "mango");
+        List<MoimSimpleResponse> blankResponses = moimFinder.searchMoim(universityId, " ");
+        List<MoimSimpleResponse> noneResponses = moimFinder.searchMoim(universityId, "none");
+        List<MoimSimpleResponse> applemangoResponses = moimFinder.searchMoim(universityId, "apple mango");
 
         //then
         assertThat(appleResponses.size()).isEqualTo(3);
@@ -556,6 +561,49 @@ class MoimFinderTest extends ImplementTest {
         assertThat(blankResponses.size()).isEqualTo(3);
         assertThat(noneResponses.size()).isEqualTo(0);
         assertThat(applemangoResponses.size()).isEqualTo(2);
+    }
+
+    @DisplayName("다른 대학 모임은 검색되지 않는다.")
+    @Test
+    void searchMoimBySearchParamAndUniversityId() {
+        // given1
+        long universityId = UNIV_ID.longValue();
+        long otherUniversityId = UNIV_ID.longValue() + 1 ;
+
+        MoimJpaEntity moimA = MoimJpaEntity.builder()
+                .universityId(universityId)
+                .title("appleMango")
+                .build();
+
+        // given2
+        MoimJpaEntity moimB = MoimJpaEntity.builder()
+                .universityId(universityId)
+                .title(" " + "apple" + " " + "mango" + " ")
+                .build();
+
+        // given3
+        MoimJpaEntity moimC = MoimJpaEntity.builder()
+                .universityId(otherUniversityId)
+                .title("apple" + " " + "mango")
+                .build();
+
+        moimRepository.save(moimA);
+        moimRepository.save(moimB);
+        moimRepository.save(moimC);
+
+        //when
+        List<MoimSimpleResponse> appleResponses = moimFinder.searchMoim(universityId, "apple");
+        List<MoimSimpleResponse> mangoResponses = moimFinder.searchMoim(universityId, "mango");
+        List<MoimSimpleResponse> blankResponses = moimFinder.searchMoim(universityId, " ");
+        List<MoimSimpleResponse> noneResponses = moimFinder.searchMoim(universityId, "none");
+        List<MoimSimpleResponse> applemangoResponses = moimFinder.searchMoim(otherUniversityId, "apple mango");
+
+        //then
+        assertThat(appleResponses.size()).isEqualTo(2);
+        assertThat(mangoResponses.size()).isEqualTo(2);
+        assertThat(blankResponses.size()).isEqualTo(2);
+        assertThat(noneResponses.size()).isEqualTo(0);
+        assertThat(applemangoResponses.size()).isEqualTo(1);
     }
 
     private MemberJpaEntity saveRandomMember() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #170 

## 📝작업 내용

> 미팅 생성시 모임장만 생성할 수 있도록 검증
> 테스트
> 모임 리스트 조회시 같은 대학 모임만 조회하도록 수정
> 테스트
> 모임 검색시 같은 대학 모임만 검색할 수 있도록 수정
> 테스트

## 💬리뷰 요구사항(선택)

> 기존에 없던 검증 로직들을 추가하였습니다. 테스트 코드 위주로 봐주시면 될 것 같습니당.
