### PR TITLE
[BE] 이메일 수신 차단 여부 설정

### DIFF
--- a/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeService.java
+++ b/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeService.java
@@ -1,6 +1,10 @@
 package moim_today.application.email_subscribe;
 
+import moim_today.dto.mail.EmailSubscriptionResponse;
+
 public interface EmailSubscribeService {
+
+    EmailSubscriptionResponse getSubscriptionStatus(final long memberId);
 
     void updateSubscribeStatus(final long memberId, final boolean subscribedStatus);
 }

--- a/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeService.java
+++ b/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeService.java
@@ -1,0 +1,6 @@
+package moim_today.application.email_subscribe;
+
+public interface EmailSubscribeService {
+
+    void updateSubscribeStatus(final long memberId, final boolean subscribedStatus);
+}

--- a/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeServiceImpl.java
@@ -1,0 +1,19 @@
+package moim_today.application.email_subscribe;
+
+import moim_today.implement.email_subscribe.EmailSubscribeUpdater;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailSubscribeServiceImpl implements EmailSubscribeService {
+
+    private final EmailSubscribeUpdater emailSubscribeUpdater;
+
+    public EmailSubscribeServiceImpl(final EmailSubscribeUpdater emailSubscribeUpdater) {
+        this.emailSubscribeUpdater = emailSubscribeUpdater;
+    }
+
+    @Override
+    public void updateSubscribeStatus(final long memberId, final boolean subscribedStatus) {
+        emailSubscribeUpdater.updateSubscribeStatus(memberId, subscribedStatus);
+    }
+}

--- a/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/email_subscribe/EmailSubscribeServiceImpl.java
@@ -1,15 +1,26 @@
 package moim_today.application.email_subscribe;
 
+import moim_today.dto.mail.EmailSubscriptionResponse;
 import moim_today.implement.email_subscribe.EmailSubscribeUpdater;
+import moim_today.implement.email_subscribe.EmailSubscriptionFinder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EmailSubscribeServiceImpl implements EmailSubscribeService {
 
     private final EmailSubscribeUpdater emailSubscribeUpdater;
+    private final EmailSubscriptionFinder emailSubscriptionFinder;
 
-    public EmailSubscribeServiceImpl(final EmailSubscribeUpdater emailSubscribeUpdater) {
+    public EmailSubscribeServiceImpl(final EmailSubscribeUpdater emailSubscribeUpdater,
+                                     final EmailSubscriptionFinder emailSubscriptionFinder) {
         this.emailSubscribeUpdater = emailSubscribeUpdater;
+        this.emailSubscriptionFinder = emailSubscriptionFinder;
+    }
+
+    @Override
+    public EmailSubscriptionResponse getSubscriptionStatus(final long memberId) {
+        boolean subscriptionStatus = emailSubscriptionFinder.getSubscriptionStatus(memberId);
+        return EmailSubscriptionResponse.of(subscriptionStatus);
     }
 
     @Override

--- a/backend/src/main/java/moim_today/dto/mail/EmailSubscribeRequest.java
+++ b/backend/src/main/java/moim_today/dto/mail/EmailSubscribeRequest.java
@@ -1,0 +1,6 @@
+package moim_today.dto.mail;
+
+public record EmailSubscribeRequest(
+        boolean subscribeStatus
+) {
+}

--- a/backend/src/main/java/moim_today/dto/mail/EmailSubscribeRequest.java
+++ b/backend/src/main/java/moim_today/dto/mail/EmailSubscribeRequest.java
@@ -1,6 +1,15 @@
 package moim_today.dto.mail;
 
+import lombok.Builder;
+
+@Builder
 public record EmailSubscribeRequest(
         boolean subscribeStatus
 ) {
+
+    public static EmailSubscribeRequest of(final boolean subscribeStatus) {
+        return EmailSubscribeRequest.builder()
+                .subscribeStatus(subscribeStatus)
+                .build();
+    }
 }

--- a/backend/src/main/java/moim_today/dto/mail/EmailSubscriptionResponse.java
+++ b/backend/src/main/java/moim_today/dto/mail/EmailSubscriptionResponse.java
@@ -1,0 +1,15 @@
+package moim_today.dto.mail;
+
+import lombok.Builder;
+
+@Builder
+public record EmailSubscriptionResponse(
+        boolean subscribeStatus
+) {
+
+    public static EmailSubscriptionResponse of(final boolean subscribeStatus) {
+        return EmailSubscriptionResponse.builder()
+                .subscribeStatus(subscribeStatus)
+                .build();
+    }
+}

--- a/backend/src/main/java/moim_today/global/constant/exception/MailExceptionConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/exception/MailExceptionConstant.java
@@ -5,7 +5,9 @@ public enum MailExceptionConstant {
     MAIL_SEND_ERROR("메일 전송 도중에 에러가 발생했습니다. 관리자에게 문의 바랍니다."),
     MAIL_CERTIFICATION_TOKEN_NOT_FOUND_ERROR("메일 인증 정보를 찾을 수 없습니다."),
     WRONG_EMAIL_FROM_ERROR("잘못된 이메일 형식입니다."),
-    MAIL_INVALID_FORMAT_ERROR("올바른 메일 형식이 아닙니다.");
+    MAIL_INVALID_FORMAT_ERROR("올바른 메일 형식이 아닙니다."),
+
+    MAIL_SUBSCRIBE_NOT_FOUND_ERROR("메일 수신 여부가 존재하지 않습니다.");
 
     private final String message;
 

--- a/backend/src/main/java/moim_today/implement/email_subscribe/EmailSubscribeAppender.java
+++ b/backend/src/main/java/moim_today/implement/email_subscribe/EmailSubscribeAppender.java
@@ -1,0 +1,22 @@
+package moim_today.implement.email_subscribe;
+
+import moim_today.global.annotation.Implement;
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+import moim_today.persistence.repository.email_subscribe.EmailSubscribeRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Implement
+public class EmailSubscribeAppender {
+
+    private final EmailSubscribeRepository emailSubscribeRepository;
+
+    public EmailSubscribeAppender(final EmailSubscribeRepository emailSubscribeRepository) {
+        this.emailSubscribeRepository = emailSubscribeRepository;
+    }
+
+    @Transactional
+    public void saveEmailSubscription(final long memberId, final boolean subscribeStatus) {
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.toEntity(memberId, subscribeStatus);
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+    }
+}

--- a/backend/src/main/java/moim_today/implement/email_subscribe/EmailSubscribeUpdater.java
+++ b/backend/src/main/java/moim_today/implement/email_subscribe/EmailSubscribeUpdater.java
@@ -1,0 +1,22 @@
+package moim_today.implement.email_subscribe;
+
+import moim_today.global.annotation.Implement;
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+import moim_today.persistence.repository.email_subscribe.EmailSubscribeRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Implement
+public class EmailSubscribeUpdater {
+
+    private final EmailSubscribeRepository emailSubscribeRepository;
+
+    public EmailSubscribeUpdater(final EmailSubscribeRepository emailSubscribeRepository) {
+        this.emailSubscribeRepository = emailSubscribeRepository;
+    }
+
+    @Transactional
+    public void updateSubscribeStatus(final long memberId, final boolean subscribeStatus) {
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = emailSubscribeRepository.getByMemberId(memberId);
+        emailSubscribeJpaEntity.updateSubscribeStatus(subscribeStatus);
+    }
+}

--- a/backend/src/main/java/moim_today/implement/email_subscribe/EmailSubscriptionFinder.java
+++ b/backend/src/main/java/moim_today/implement/email_subscribe/EmailSubscriptionFinder.java
@@ -1,0 +1,20 @@
+package moim_today.implement.email_subscribe;
+
+import moim_today.global.annotation.Implement;
+import moim_today.persistence.repository.email_subscribe.EmailSubscribeRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Implement
+public class EmailSubscriptionFinder {
+
+    private final EmailSubscribeRepository emailSubscribeRepository;
+
+    public EmailSubscriptionFinder(final EmailSubscribeRepository emailSubscribeRepository) {
+        this.emailSubscribeRepository = emailSubscribeRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean getSubscriptionStatus(final long memberId) {
+        return emailSubscribeRepository.getSubscriptionStatus(memberId);
+    }
+}

--- a/backend/src/main/java/moim_today/implement/mail/MailScheduler.java
+++ b/backend/src/main/java/moim_today/implement/mail/MailScheduler.java
@@ -17,7 +17,7 @@ import static moim_today.global.constant.MailConstant.*;
 @Implement
 public class MailScheduler {
 
-    private static final int ONE_HOUR_IN_MILLISECONDS = 60 * 60 * 1000;
+    private static final String HOURLY_CRON_EXPRESSION = "0 0 * * * *";
 
     private final MailSender mailSender;
     private final MeetingFinder meetingFinder;
@@ -30,7 +30,7 @@ public class MailScheduler {
         this.joinedMeetingUpdater = joinedMeetingUpdater;
     }
 
-    @Scheduled(fixedRate = ONE_HOUR_IN_MILLISECONDS)
+    @Scheduled(cron = HOURLY_CRON_EXPRESSION)
     public void sendUpcomingMeetingMails() {
         LocalDateTime currentDateTime = LocalDateTime.now();
         List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);

--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
@@ -17,7 +17,7 @@ public class JoinedMeetingUpdater {
     @Transactional
     public void updateAttendance(final long memberId, final long meetingId, final boolean attendance) {
         JoinedMeetingJpaEntity joinedMeetingJpaEntity =
-                joinedMeetingRepository.findByMemberIdAndMeetingId(memberId, meetingId);
+                joinedMeetingRepository.getByMemberIdAndMeetingId(memberId, meetingId);
         joinedMeetingJpaEntity.updateAttendance(attendance);
     }
 

--- a/backend/src/main/java/moim_today/implement/member/AuthManager.java
+++ b/backend/src/main/java/moim_today/implement/member/AuthManager.java
@@ -8,6 +8,7 @@ import moim_today.dto.auth.MemberLoginRequest;
 import moim_today.dto.auth.MemberSignUpRequest;
 import moim_today.global.annotation.Implement;
 import moim_today.global.error.NotFoundException;
+import moim_today.implement.email_subscribe.EmailSubscribeAppender;
 import moim_today.persistence.entity.member.MemberJpaEntity;
 import moim_today.persistence.repository.member.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,13 +22,16 @@ public class AuthManager {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final ObjectMapper objectMapper;
+    private final EmailSubscribeAppender emailSubscribeAppender;
 
     public AuthManager(final MemberRepository memberRepository,
                        final PasswordEncoder passwordEncoder,
-                       final ObjectMapper objectMapper) {
+                       final ObjectMapper objectMapper,
+                       final EmailSubscribeAppender emailSubscribeAppender) {
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
         this.objectMapper = objectMapper;
+        this.emailSubscribeAppender = emailSubscribeAppender;
     }
 
     @Transactional(readOnly = true)
@@ -58,6 +62,7 @@ public class AuthManager {
         MemberSession memberSession = MemberSession.from(saveMember);
         String memberSessionJson = memberSession.toJson(objectMapper);
         memberSession.setSession(request, memberSessionJson, false);
+        emailSubscribeAppender.saveEmailSubscription(memberSession.id(), true);
     }
 
     private String passwordEncode(final String password){

--- a/backend/src/main/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntity.java
@@ -29,6 +29,13 @@ public class EmailSubscribeJpaEntity extends BaseTimeEntity {
         this.subscribeStatus = subscribeStatus;
     }
 
+    public static EmailSubscribeJpaEntity toEntity(final long memberId, final boolean subscribeStatus) {
+        return EmailSubscribeJpaEntity.builder()
+                .memberId(memberId)
+                .subscribeStatus(subscribeStatus)
+                .build();
+    }
+
     public void updateSubscribeStatus(final boolean subscribeStatus) {
         this.subscribeStatus = subscribeStatus;
     }

--- a/backend/src/main/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntity.java
@@ -1,0 +1,26 @@
+package moim_today.persistence.entity.email_subscribe;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import moim_today.global.base_entity.BaseTimeEntity;
+
+@Getter
+@Table(name = "email_subscribe")
+@Entity
+public class EmailSubscribeJpaEntity extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "email_subscribe_id")
+    private long id;
+
+    private boolean subscribeStatus;
+
+    protected EmailSubscribeJpaEntity() {
+    }
+
+    @Builder
+    private EmailSubscribeJpaEntity(final boolean subscribeStatus) {
+        this.subscribeStatus = subscribeStatus;
+    }
+}

--- a/backend/src/main/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntity.java
@@ -3,6 +3,7 @@ package moim_today.persistence.entity.email_subscribe;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import moim_today.global.annotation.Association;
 import moim_today.global.base_entity.BaseTimeEntity;
 
 @Getter
@@ -14,13 +15,21 @@ public class EmailSubscribeJpaEntity extends BaseTimeEntity {
     @Column(name = "email_subscribe_id")
     private long id;
 
+    @Association
+    private long memberId;
+
     private boolean subscribeStatus;
 
     protected EmailSubscribeJpaEntity() {
     }
 
     @Builder
-    private EmailSubscribeJpaEntity(final boolean subscribeStatus) {
+    private EmailSubscribeJpaEntity(final long memberId, final boolean subscribeStatus) {
+        this.memberId = memberId;
+        this.subscribeStatus = subscribeStatus;
+    }
+
+    public void updateSubscribeStatus(final boolean subscribeStatus) {
         this.subscribeStatus = subscribeStatus;
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeJpaRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeJpaRepository.java
@@ -1,0 +1,7 @@
+package moim_today.persistence.repository.email_subscribe;
+
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailSubscribeJpaRepository extends JpaRepository<EmailSubscribeJpaEntity, Long> {
+}

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeJpaRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeJpaRepository.java
@@ -3,5 +3,9 @@ package moim_today.persistence.repository.email_subscribe;
 import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EmailSubscribeJpaRepository extends JpaRepository<EmailSubscribeJpaEntity, Long> {
+
+    Optional<EmailSubscribeJpaEntity> findByMemberId(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
@@ -12,4 +12,6 @@ public interface EmailSubscribeRepository {
     EmailSubscribeJpaEntity save(final EmailSubscribeJpaEntity emailSubscribeJpaEntity);
 
     boolean getSubscriptionStatus(final long memberId);
+
+    long count();
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
@@ -1,0 +1,4 @@
+package moim_today.persistence.repository.email_subscribe;
+
+public interface EmailSubscribeRepository {
+}

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
@@ -10,4 +10,6 @@ public interface EmailSubscribeRepository {
     EmailSubscribeJpaEntity getByMemberId(final long memberId);
 
     EmailSubscribeJpaEntity save(final EmailSubscribeJpaEntity emailSubscribeJpaEntity);
+
+    boolean getSubscriptionStatus(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
@@ -1,4 +1,9 @@
 package moim_today.persistence.repository.email_subscribe;
 
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+
+
 public interface EmailSubscribeRepository {
+
+    EmailSubscribeJpaEntity getByMemberId(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepository.java
@@ -5,5 +5,9 @@ import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
 
 public interface EmailSubscribeRepository {
 
+    EmailSubscribeJpaEntity getById(final long emailSubscribeId);
+
     EmailSubscribeJpaEntity getByMemberId(final long memberId);
+
+    EmailSubscribeJpaEntity save(final EmailSubscribeJpaEntity emailSubscribeJpaEntity);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
@@ -16,8 +16,19 @@ public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
     }
 
     @Override
+    public EmailSubscribeJpaEntity getById(final long emailSubscribeId) {
+        return emailSubscribeJpaRepository.findById(emailSubscribeId)
+                .orElseThrow(() -> new NotFoundException(MAIL_SUBSCRIBE_NOT_FOUND_ERROR.message()));
+    }
+
+    @Override
     public EmailSubscribeJpaEntity getByMemberId(final long memberId) {
         return emailSubscribeJpaRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new NotFoundException(MAIL_SUBSCRIBE_NOT_FOUND_ERROR.message()));
+    }
+
+    @Override
+    public EmailSubscribeJpaEntity save(final EmailSubscribeJpaEntity emailSubscribeJpaEntity) {
+        return emailSubscribeJpaRepository.save(emailSubscribeJpaEntity);
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
@@ -1,18 +1,23 @@
 package moim_today.persistence.repository.email_subscribe;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
 import org.springframework.stereotype.Repository;
 
 import static moim_today.global.constant.exception.MailExceptionConstant.MAIL_SUBSCRIBE_NOT_FOUND_ERROR;
+import static moim_today.persistence.entity.email_subscribe.QEmailSubscribeJpaEntity.*;
 
 @Repository
 public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
 
     private final EmailSubscribeJpaRepository emailSubscribeJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
-    public EmailSubscribeRepositoryImpl(final EmailSubscribeJpaRepository emailSubscribeJpaRepository) {
+    public EmailSubscribeRepositoryImpl(final EmailSubscribeJpaRepository emailSubscribeJpaRepository,
+                                        final JPAQueryFactory queryFactory) {
         this.emailSubscribeJpaRepository = emailSubscribeJpaRepository;
+        this.queryFactory = queryFactory;
     }
 
     @Override
@@ -30,5 +35,13 @@ public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
     @Override
     public EmailSubscribeJpaEntity save(final EmailSubscribeJpaEntity emailSubscribeJpaEntity) {
         return emailSubscribeJpaRepository.save(emailSubscribeJpaEntity);
+    }
+
+    @Override
+    public boolean getSubscriptionStatus(final long memberId) {
+        return queryFactory.select(emailSubscribeJpaEntity.subscribeStatus)
+                .from(emailSubscribeJpaEntity)
+                .where(emailSubscribeJpaEntity.memberId.eq(memberId))
+                .fetchFirst();
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
@@ -1,6 +1,10 @@
 package moim_today.persistence.repository.email_subscribe;
 
+import moim_today.global.error.NotFoundException;
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
 import org.springframework.stereotype.Repository;
+
+import static moim_today.global.constant.exception.MailExceptionConstant.MAIL_SUBSCRIBE_NOT_FOUND_ERROR;
 
 @Repository
 public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
@@ -9,5 +13,11 @@ public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
 
     public EmailSubscribeRepositoryImpl(final EmailSubscribeJpaRepository emailSubscribeJpaRepository) {
         this.emailSubscribeJpaRepository = emailSubscribeJpaRepository;
+    }
+
+    @Override
+    public EmailSubscribeJpaEntity getByMemberId(final long memberId) {
+        return emailSubscribeJpaRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotFoundException(MAIL_SUBSCRIBE_NOT_FOUND_ERROR.message()));
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
@@ -44,4 +44,9 @@ public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
                 .where(emailSubscribeJpaEntity.memberId.eq(memberId))
                 .fetchFirst();
     }
+
+    @Override
+    public long count() {
+        return emailSubscribeJpaRepository.count();
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/email_subscribe/EmailSubscribeRepositoryImpl.java
@@ -1,0 +1,13 @@
+package moim_today.persistence.repository.email_subscribe;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EmailSubscribeRepositoryImpl implements EmailSubscribeRepository {
+
+    private final EmailSubscribeJpaRepository emailSubscribeJpaRepository;
+
+    public EmailSubscribeRepositoryImpl(final EmailSubscribeJpaRepository emailSubscribeJpaRepository) {
+        this.emailSubscribeJpaRepository = emailSubscribeJpaRepository;
+    }
+}

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingJpaRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingJpaRepository.java
@@ -4,10 +4,11 @@ import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEnti
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface JoinedMeetingJpaRepository extends JpaRepository<JoinedMeetingJpaEntity, Long> {
 
     void deleteAllByMeetingIdIn(final List<Long> meetingIds);
 
-    JoinedMeetingJpaEntity findByMemberIdAndMeetingId(final long memberId, final long meetingId);
+    Optional<JoinedMeetingJpaEntity> findByMemberIdAndMeetingId(final long memberId, final long meetingId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingRepository.java
@@ -15,7 +15,7 @@ public interface JoinedMeetingRepository {
 
     List<Long> findAllMemberIdByMeetingId(final long meetingId);
 
-    JoinedMeetingJpaEntity findByMemberIdAndMeetingId(final long memberId, final long meetingId);
+    JoinedMeetingJpaEntity getByMemberIdAndMeetingId(final long memberId, final long meetingId);
 
     List<JoinedMeetingJpaEntity> findAll();
 

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingRepositoryImpl.java
@@ -9,6 +9,7 @@ import moim_today.persistence.entity.meeting.joined_meeting.QJoinedMeetingJpaEnt
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static moim_today.global.constant.exception.MeetingExceptionConstant.JOINED_MEETING_NOT_FOUND_ERROR;
 import static moim_today.persistence.entity.meeting.joined_meeting.QJoinedMeetingJpaEntity.joinedMeetingJpaEntity;
@@ -50,8 +51,9 @@ public class JoinedMeetingRepositoryImpl implements JoinedMeetingRepository {
     }
 
     @Override
-    public JoinedMeetingJpaEntity findByMemberIdAndMeetingId(final long memberId, final long meetingId) {
-        return joinedMeetingJpaRepository.findByMemberIdAndMeetingId(memberId, meetingId);
+    public JoinedMeetingJpaEntity getByMemberIdAndMeetingId(final long memberId, final long meetingId) {
+        return joinedMeetingJpaRepository.findByMemberIdAndMeetingId(memberId, meetingId)
+                .orElseThrow(() -> new NotFoundException(JOINED_MEETING_NOT_FOUND_ERROR.message()));
     }
 
     @Override

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepositoryImpl.java
@@ -6,7 +6,9 @@ import moim_today.dto.mail.UpcomingMeetingNoticeResponse;
 import moim_today.dto.meeting.meeting.MeetingSimpleDao;
 import moim_today.dto.meeting.meeting.QMeetingSimpleDao;
 import moim_today.global.error.NotFoundException;
+import moim_today.persistence.entity.email_subscribe.QEmailSubscribeJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.member.QMemberJpaEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static moim_today.global.constant.exception.MeetingExceptionConstant.MEETING_NOT_FOUND_ERROR;
+import static moim_today.persistence.entity.email_subscribe.QEmailSubscribeJpaEntity.*;
 import static moim_today.persistence.entity.meeting.joined_meeting.QJoinedMeetingJpaEntity.joinedMeetingJpaEntity;
 import static moim_today.persistence.entity.meeting.meeting.QMeetingJpaEntity.meetingJpaEntity;
 import static moim_today.persistence.entity.member.QMemberJpaEntity.memberJpaEntity;
@@ -130,10 +133,13 @@ public class MeetingRepositoryImpl implements MeetingRepository {
                 .from(meetingJpaEntity)
                 .innerJoin(joinedMeetingJpaEntity).on(joinedMeetingJpaEntity.meetingId.eq(meetingJpaEntity.id))
                 .innerJoin(memberJpaEntity).on(memberJpaEntity.id.eq(joinedMeetingJpaEntity.memberId))
+                .innerJoin(emailSubscribeJpaEntity).on(memberJpaEntity.id.eq(emailSubscribeJpaEntity.memberId))
                 .where(
                         meetingJpaEntity.startDateTime.loe(upcomingDateTime)
                                 .and(meetingJpaEntity.startDateTime.after(currentDateTime)
-                                        .and(joinedMeetingJpaEntity.upcomingNoticeSent.isFalse()))
+                                        .and(joinedMeetingJpaEntity.upcomingNoticeSent.isFalse())
+                                        .and(emailSubscribeJpaEntity.subscribeStatus.isTrue())
+                                )
                 )
                 .fetch();
     }

--- a/backend/src/main/java/moim_today/presentation/email_subscribe/EmailSubscribeController.java
+++ b/backend/src/main/java/moim_today/presentation/email_subscribe/EmailSubscribeController.java
@@ -3,11 +3,9 @@ package moim_today.presentation.email_subscribe;
 import moim_today.application.email_subscribe.EmailSubscribeService;
 import moim_today.domain.member.MemberSession;
 import moim_today.dto.mail.EmailSubscribeRequest;
+import moim_today.dto.mail.EmailSubscriptionResponse;
 import moim_today.global.annotation.Login;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api")
 @RestController
@@ -17,6 +15,11 @@ public class EmailSubscribeController {
 
     public EmailSubscribeController(final EmailSubscribeService emailSubscribeService) {
         this.emailSubscribeService = emailSubscribeService;
+    }
+
+    @GetMapping("/email-subscription")
+    public EmailSubscriptionResponse getEmailSubscriptionStatus(@Login final MemberSession memberSession) {
+        return emailSubscribeService.getSubscriptionStatus(memberSession.id());
     }
 
     @PostMapping("/email-subscription")

--- a/backend/src/main/java/moim_today/presentation/email_subscribe/EmailSubscribeController.java
+++ b/backend/src/main/java/moim_today/presentation/email_subscribe/EmailSubscribeController.java
@@ -23,7 +23,7 @@ public class EmailSubscribeController {
     }
 
     @PostMapping("/email-subscription")
-    public void subscribeEmail(@Login final MemberSession memberSession,
+    public void updateEmailSubscribeStatus(@Login final MemberSession memberSession,
                                @RequestBody final EmailSubscribeRequest emailSubscribeRequest) {
         emailSubscribeService.updateSubscribeStatus(memberSession.id(), emailSubscribeRequest.subscribeStatus());
     }

--- a/backend/src/main/java/moim_today/presentation/email_subscribe/EmailSubscribeController.java
+++ b/backend/src/main/java/moim_today/presentation/email_subscribe/EmailSubscribeController.java
@@ -1,0 +1,27 @@
+package moim_today.presentation.email_subscribe;
+
+import moim_today.application.email_subscribe.EmailSubscribeService;
+import moim_today.domain.member.MemberSession;
+import moim_today.dto.mail.EmailSubscribeRequest;
+import moim_today.global.annotation.Login;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+public class EmailSubscribeController {
+
+    private final EmailSubscribeService emailSubscribeService;
+
+    public EmailSubscribeController(final EmailSubscribeService emailSubscribeService) {
+        this.emailSubscribeService = emailSubscribeService;
+    }
+
+    @PostMapping("/email-subscription")
+    public void subscribeEmail(@Login final MemberSession memberSession,
+                               @RequestBody final EmailSubscribeRequest emailSubscribeRequest) {
+        emailSubscribeService.updateSubscribeStatus(memberSession.id(), emailSubscribeRequest.subscribeStatus());
+    }
+}

--- a/backend/src/test/java/moim_today/fake_class/email_subscribe/FakeEmailSubscribeService.java
+++ b/backend/src/test/java/moim_today/fake_class/email_subscribe/FakeEmailSubscribeService.java
@@ -12,6 +12,6 @@ public class FakeEmailSubscribeService implements EmailSubscribeService {
 
     @Override
     public EmailSubscriptionResponse getSubscriptionStatus(final long memberId) {
-        return null;
+        return EmailSubscriptionResponse.of(true);
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/email_subscribe/FakeEmailSubscribeService.java
+++ b/backend/src/test/java/moim_today/fake_class/email_subscribe/FakeEmailSubscribeService.java
@@ -1,11 +1,17 @@
 package moim_today.fake_class.email_subscribe;
 
 import moim_today.application.email_subscribe.EmailSubscribeService;
+import moim_today.dto.mail.EmailSubscriptionResponse;
 
 public class FakeEmailSubscribeService implements EmailSubscribeService {
 
     @Override
     public void updateSubscribeStatus(final long memberId, final boolean subscribedStatus) {
 
+    }
+
+    @Override
+    public EmailSubscriptionResponse getSubscriptionStatus(final long memberId) {
+        return null;
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/email_subscribe/FakeEmailSubscribeService.java
+++ b/backend/src/test/java/moim_today/fake_class/email_subscribe/FakeEmailSubscribeService.java
@@ -1,0 +1,11 @@
+package moim_today.fake_class.email_subscribe;
+
+import moim_today.application.email_subscribe.EmailSubscribeService;
+
+public class FakeEmailSubscribeService implements EmailSubscribeService {
+
+    @Override
+    public void updateSubscribeStatus(final long memberId, final boolean subscribedStatus) {
+
+    }
+}

--- a/backend/src/test/java/moim_today/implement/email_subscribe/EmailSubscribeAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/email_subscribe/EmailSubscribeAppenderTest.java
@@ -1,0 +1,33 @@
+package moim_today.implement.email_subscribe;
+
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+import moim_today.util.ImplementTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static moim_today.util.TestConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+class EmailSubscribeAppenderTest extends ImplementTest {
+
+    @Autowired
+    private EmailSubscribeAppender emailSubscribeAppender;
+
+    @DisplayName("이메일 수신 여부 정보를 저장한다.")
+    @Test
+    void saveEmailSubscription() {
+        // given
+        long memberId = MEMBER_ID.longValue();
+        boolean subscriptionStatus = true;
+
+        // when
+        emailSubscribeAppender.saveEmailSubscription(memberId, subscriptionStatus);
+
+        // then
+        EmailSubscribeJpaEntity findEntity = emailSubscribeRepository.getByMemberId(memberId);
+
+        assertThat(emailSubscribeRepository.count()).isEqualTo(1);
+        assertThat(findEntity.isSubscribeStatus()).isTrue();
+    }
+}

--- a/backend/src/test/java/moim_today/implement/email_subscribe/EmailSubscribeUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/email_subscribe/EmailSubscribeUpdaterTest.java
@@ -1,0 +1,38 @@
+package moim_today.implement.email_subscribe;
+
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+import moim_today.util.ImplementTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static moim_today.util.TestConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+
+class EmailSubscribeUpdaterTest extends ImplementTest {
+
+    @Autowired
+    private EmailSubscribeUpdater emailSubscribeUpdater;
+
+    @DisplayName("이메일 수신 여부 설정을 변경한다.")
+    @Test
+    void updateSubscribeStatus() {
+        // given
+        long memberId = MEMBER_ID.longValue();
+
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberId)
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+
+        // when
+        emailSubscribeUpdater.updateSubscribeStatus(memberId, false);
+
+        // then
+        EmailSubscribeJpaEntity findEntity = emailSubscribeRepository.getById(emailSubscribeJpaEntity.getId());
+        assertThat(findEntity.isSubscribeStatus()).isFalse();
+    }
+}

--- a/backend/src/test/java/moim_today/implement/email_subscribe/EmailSubscriptionFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/email_subscribe/EmailSubscriptionFinderTest.java
@@ -1,0 +1,36 @@
+package moim_today.implement.email_subscribe;
+
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
+import moim_today.util.ImplementTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static moim_today.util.TestConstant.*;
+import static org.assertj.core.api.Assertions.*;
+
+class EmailSubscriptionFinderTest extends ImplementTest {
+
+    @Autowired
+    private EmailSubscriptionFinder emailSubscriptionFinder;
+
+    @DisplayName("해당 회원의 이메일 수신 여부를 조회한다.")
+    @Test
+    void getSubscriptionStatus() {
+        // given
+        long memberId = MEMBER_ID.longValue();
+
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberId)
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+
+        // when
+        boolean subscriptionStatus = emailSubscriptionFinder.getSubscriptionStatus(memberId);
+
+        // then
+        assertThat(subscriptionStatus).isTrue();
+    }
+}

--- a/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingFinderTest.java
@@ -5,6 +5,7 @@ import moim_today.dto.mail.UpcomingMeetingNoticeResponse;
 import moim_today.dto.meeting.meeting.MeetingDetailResponse;
 import moim_today.dto.meeting.meeting.MeetingSimpleDao;
 import moim_today.global.error.NotFoundException;
+import moim_today.persistence.entity.email_subscribe.EmailSubscribeJpaEntity;
 import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.member.MemberJpaEntity;
@@ -308,7 +309,6 @@ class MeetingFinderTest extends ImplementTest {
         assertThat(meetingSimpleDaos.get(1).agenda()).isEqualTo(SECOND_CREATED_MEETING_AGENDA.value());
     }
 
-
     @DisplayName("하나의 모임의 모든 미팅의 엔티티 정보를 반환한다.")
     @Test
     void findAllByMoimId() {
@@ -456,6 +456,13 @@ class MeetingFinderTest extends ImplementTest {
 
         joinedMeetingRepository.save(joinedMeetingJpaEntity);
 
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+
         // when
         List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);
 
@@ -469,6 +476,100 @@ class MeetingFinderTest extends ImplementTest {
         assertThat(upcomingNotice.endDateTime()).isEqualTo(meetingJpaEntity.getEndDateTime());
         assertThat(upcomingNotice.place()).isEqualTo(meetingJpaEntity.getPlace());
         assertThat(upcomingNotice.attendance()).isEqualTo(joinedMeetingJpaEntity.isAttendance());
+    }
+
+    @DisplayName("이메일 수신 여부를 수락한 사람만 다가오는 미팅 정보를 조회한다.")
+    @Test
+    void findUpcomingNoticesOnlySubscribeStatusTrue() {
+        // given 1
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 4, 8, 0, 0);
+
+        // given 2
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .email(EMAIL.value())
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 3
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .agenda(MEETING_AGENDA.value())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 12, 0, 0))
+                .place(MEETING_PLACE.value())
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 4
+        JoinedMeetingJpaEntity joinedMeetingJpaEntity = JoinedMeetingJpaEntity.builder()
+                .meetingId(meetingJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .attendance(true)
+                .upcomingNoticeSent(false)
+                .build();
+
+        joinedMeetingRepository.save(joinedMeetingJpaEntity);
+
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+
+        // when
+        List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);
+
+        // then
+        assertThat(upcomingNotices.size()).isEqualTo(1);
+    }
+
+    @DisplayName("이메일 수신 여부를 거절한 사람은 다가오는 미팅 정보가 조회되지 않는다.")
+    @Test
+    void findUpcomingNoticesOnlySubscribeStatusFalse() {
+        // given 1
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 4, 8, 0, 0);
+
+        // given 2
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .email(EMAIL.value())
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 3
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .agenda(MEETING_AGENDA.value())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 12, 0, 0))
+                .place(MEETING_PLACE.value())
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 4
+        JoinedMeetingJpaEntity joinedMeetingJpaEntity = JoinedMeetingJpaEntity.builder()
+                .meetingId(meetingJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .attendance(true)
+                .upcomingNoticeSent(false)
+                .build();
+
+        joinedMeetingRepository.save(joinedMeetingJpaEntity);
+
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .subscribeStatus(false)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+
+        // when
+        List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);
+
+        // then
+        assertThat(upcomingNotices.size()).isEqualTo(0);
     }
 
     @DisplayName("다가오는 미팅은 시작 시간이 현재 시간보다 뒤에 있는 시간대를 조회한다.")
@@ -519,6 +620,13 @@ class MeetingFinderTest extends ImplementTest {
 
         joinedMeetingRepository.save(beforeJoinedMeetingJpaEntity);
         joinedMeetingRepository.save(afterJoinedMeetingJpaEntity);
+
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
 
         // when
         List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);
@@ -576,6 +684,13 @@ class MeetingFinderTest extends ImplementTest {
         joinedMeetingRepository.save(beforeJoinedMeetingJpaEntity);
         joinedMeetingRepository.save(afterJoinedMeetingJpaEntity);
 
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
+
         // when
         List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);
 
@@ -631,6 +746,13 @@ class MeetingFinderTest extends ImplementTest {
 
         joinedMeetingRepository.save(beforeJoinedMeetingJpaEntity);
         joinedMeetingRepository.save(afterJoinedMeetingJpaEntity);
+
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .subscribeStatus(true)
+                .build();
+
+        emailSubscribeRepository.save(emailSubscribeJpaEntity);
 
         // when
         List<UpcomingMeetingNoticeResponse> upcomingNotices = meetingFinder.findUpcomingNotices(currentDateTime);

--- a/backend/src/test/java/moim_today/implement/member/AuthManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/member/AuthManagerTest.java
@@ -126,7 +126,7 @@ class AuthManagerTest extends ImplementTest {
 
     @DisplayName("정상적으로 회원가입을 완료하면 멤버 데이터를 넣고 세션에 등록한다")
     @Test
-    void register() throws JsonProcessingException {
+    void signUp() throws JsonProcessingException {
         // given
         LocalDate birthDate = LocalDate.now();
         MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
@@ -152,5 +152,6 @@ class AuthManagerTest extends ImplementTest {
         assertThat(memberSessionObject).isNotBlank();
         MemberSession memberSession = objectMapper.readValue(memberSessionObject, MemberSession.class);
         assertThat(memberSession.username()).isEqualTo(USERNAME.value());
+        assertThat(emailSubscribeRepository.count()).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/email_subscribe/EmailSubscribeJpaEntityTest.java
@@ -1,0 +1,24 @@
+package moim_today.persistence.entity.email_subscribe;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class EmailSubscribeJpaEntityTest {
+
+    @DisplayName("이메일 수신 여부 설정을 변경한다.")
+    @Test
+    void updateSubscribeStatus() {
+        // given
+        EmailSubscribeJpaEntity emailSubscribeJpaEntity = EmailSubscribeJpaEntity.builder()
+                .subscribeStatus(true)
+                .build();
+
+        // when
+        emailSubscribeJpaEntity.updateSubscribeStatus(false);
+
+        // then
+        assertThat(emailSubscribeJpaEntity.isSubscribeStatus()).isFalse();
+    }
+}

--- a/backend/src/test/java/moim_today/presentation/email_subscribe/EmailSubscribeControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/email_subscribe/EmailSubscribeControllerTest.java
@@ -1,0 +1,51 @@
+package moim_today.presentation.email_subscribe;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import moim_today.application.email_subscribe.EmailSubscribeService;
+import moim_today.dto.mail.EmailSubscribeRequest;
+import moim_today.fake_class.email_subscribe.FakeEmailSubscribeService;
+import moim_today.util.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class EmailSubscribeControllerTest extends ControllerTest {
+
+    private final EmailSubscribeService emailSubscribeService = new FakeEmailSubscribeService();
+
+    @Override
+    protected Object initController() {
+        return new EmailSubscribeController(emailSubscribeService);
+    }
+
+    @DisplayName("이메일 수신 여부 정보를 변경한다.")
+    @Test
+    void subscribeEmail() throws Exception {
+        EmailSubscribeRequest emailSubscribeRequest = EmailSubscribeRequest.of(true);
+        String json = objectMapper.writeValueAsString(emailSubscribeRequest);
+
+        mockMvc.perform(
+                        post("/api/email-subscription")
+                                .contentType(APPLICATION_JSON)
+                                .content(json)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("이메일 수신 여부를 변경한다.",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("미팅")
+                                .summary("이메일 수신 정보 변경")
+                                .requestFields(
+                                        fieldWithPath("subscribeStatus").type(BOOLEAN).description("수신 여부")
+                                )
+                                .build()
+                        )));
+    }
+}

--- a/backend/src/test/java/moim_today/presentation/email_subscribe/EmailSubscribeControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/email_subscribe/EmailSubscribeControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -26,9 +27,27 @@ class EmailSubscribeControllerTest extends ControllerTest {
         return new EmailSubscribeController(emailSubscribeService);
     }
 
+    @DisplayName("해당 회원의 이메일 수신 여부 정보를 조회한다.")
+    @Test
+    void getEmailSubscriptionStatus() throws Exception {
+        mockMvc.perform(
+                        get("/api/email-subscription")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("해당 회원의 이메일 수신 여부를 조회한다.",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("미팅")
+                                .summary("이메일 수신 정보 조회")
+                                .responseFields(
+                                        fieldWithPath("subscribeStatus").type(BOOLEAN).description("수신 여부")
+                                )
+                                .build()
+                        )));
+    }
+
     @DisplayName("이메일 수신 여부 정보를 변경한다.")
     @Test
-    void subscribeEmail() throws Exception {
+    void updateEmailSubscribeStatus() throws Exception {
         EmailSubscribeRequest emailSubscribeRequest = EmailSubscribeRequest.of(true);
         String json = objectMapper.writeValueAsString(emailSubscribeRequest);
 

--- a/backend/src/test/java/moim_today/util/ImplementTest.java
+++ b/backend/src/test/java/moim_today/util/ImplementTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import moim_today.persistence.repository.certification.email.EmailCertificationRepository;
 import moim_today.persistence.repository.certification.password.PasswordCertificationRepository;
 import moim_today.persistence.repository.department.DepartmentRepository;
+import moim_today.persistence.repository.email_subscribe.EmailSubscribeRepository;
 import moim_today.persistence.repository.meeting.joined_meeting.JoinedMeetingRepository;
 import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
 import moim_today.persistence.repository.meeting.meeting_comment.MeetingCommentRepository;
@@ -75,6 +76,9 @@ public abstract class ImplementTest {
 
     @Autowired
     protected MeetingCommentRepository meetingCommentRepository;
+
+    @Autowired
+    protected EmailSubscribeRepository emailSubscribeRepository;
 
     @BeforeEach
     void setUpDatabase() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #167 

## 📝작업 내용

> 이메일 수신 차단 여부 Entity/Repository 추가
 이메일 수신 차단 설정 기능 구현
 로그인한 회원의 이메일 수신 정보 조회
 회원가입시 이메일 수신 차단 정보 추가
 이메일 전송할 때 수신 여부 체크
 테스트 코드 작성

## 💬리뷰 요구사항(선택)

> 새롭게 추가된 기능
> 1. 수신 여부 변경
> 2. 수신 여부 조회입니다.

> 기존 로직에 추가한 부분
> 1. 회원가입시 수신 여부 등록
> 2. 정각마다 다가오는 미팅 정보 메일 전송할 때 수신 여부 확인하는 로직

이렇게 나눠서 봐주시면 될 것 같습니당