### PR TITLE
[FEAT] 자신이 참여한 모임들을 완료 여부에 따라 조회하고 카드 정보로 반환할 수 있다

### DIFF
--- a/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
@@ -35,5 +35,5 @@ public interface MoimService {
 
     List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam);
 
-    List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended);
+    List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended, final boolean onlyHost);
 }

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface MoimService {
 
-    List<MyMoimResponse> findAllMyMoimResponse(final long memberId);
+    List<MyMoimResponse> findAllMyJoinedMoimResponse(final long memberId);
 
     MoimIdResponse createMoim(final long memberId, final long universityId,
                               final MoimCreateRequest moimCreateRequest);
@@ -34,4 +34,6 @@ public interface MoimService {
     List<MoimSimpleResponse> findAllMoimResponses(final long universityId, final MoimCategoryDto moimCategoryDto, final MoimSortedFilter moimSortedFilter);
 
     List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam);
+
+    List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended);
 }

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static moim_today.global.constant.FileTypeConstant.MOIM_IMAGE;
@@ -69,7 +70,7 @@ public class MoimServiceImpl implements MoimService{
     }
 
     @Override
-    public List<MyMoimResponse> findAllMyMoimResponse(final long memberId) {
+    public List<MyMoimResponse> findAllMyJoinedMoimResponse(final long memberId) {
         return moimFinder.findAllMyMoimResponse(memberId);
     }
 
@@ -171,5 +172,10 @@ public class MoimServiceImpl implements MoimService{
     @Override
     public List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam) {
         return moimFinder.searchMoim(universityId, searchParam);
+    }
+
+    @Override
+    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended) {
+        return moimManager.findAllJoinedMoimSimpleResponseByEndStatus(memberId, LocalDate.now(), ended);
     }
 }

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -175,7 +175,12 @@ public class MoimServiceImpl implements MoimService{
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended) {
+    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId,
+                                                                      final boolean ended,
+                                                                      final boolean onlyHost) {
+        if(onlyHost){
+            return moimManager.findAllHostMoimSimpleResponsesByEndStatus(memberId, LocalDate.now(), ended);
+        }
         return moimManager.findAllJoinedMoimSimpleResponseByEndStatus(memberId, LocalDate.now(), ended);
     }
 }

--- a/backend/src/main/java/moim_today/dto/moim/moim_notice/MoimNoticeCreateRequest.java
+++ b/backend/src/main/java/moim_today/dto/moim/moim_notice/MoimNoticeCreateRequest.java
@@ -1,7 +1,9 @@
 package moim_today.dto.moim.moim_notice;
 
+import lombok.Builder;
 import moim_today.persistence.entity.moim.moim_notice.MoimNoticeJpaEntity;
 
+@Builder
 public record MoimNoticeCreateRequest(
         long moimId,
         String title,

--- a/backend/src/main/java/moim_today/global/config/WebConfig.java
+++ b/backend/src/main/java/moim_today/global/config/WebConfig.java
@@ -29,6 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/login",
                         "/api/certification/**",
                         "/api/sign-up",
+                        "/api/session-validation",
                         "/api",
                         "/api/universities",
                         "/api/universities/departments/**",

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimFinder.java
@@ -15,6 +15,7 @@ import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static moim_today.global.constant.exception.MoimExceptionConstant.MOIM_CAPACITY_ERROR;
@@ -95,5 +96,14 @@ public class MoimFinder {
     @Transactional(readOnly = true)
     public List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam) {
         return moimRepository.searchMoimBySearchParam(universityId, searchParam);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MoimSimpleResponse> findEndedMoimSimpleResponsesByMoimIds(final List<Long> moimIds, final LocalDate now) {
+        return moimRepository.findEndedMoimSimpleResponsesByMoimIds(moimIds, now);
+    }
+
+    public List<MoimSimpleResponse> findInProgressMoimSimpleResponsesByMoimIds(final List<Long> moimIds, final LocalDate now) {
+        return moimRepository.findInProgressMoimSimpleResponsesByMoimIds(moimIds, now);
     }
 }

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimManager.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimManager.java
@@ -23,7 +23,7 @@ public class MoimManager {
     private final JoinedMoimFinder joinedMoimFinder;
     private final JoinedMoimRemover joinedMoimRemover;
     private final TodoRemover todoRemover;
-    private final MeetingFinder  meetingFinder;
+    private final MeetingFinder meetingFinder;
     private final JoinedMeetingRemover joinedMeetingRemover;
     private final JoinedMeetingAppender joinedMeetingAppender;
     private final MeetingCommentUpdater meetingCommentUpdater;
@@ -80,7 +80,7 @@ public class MoimManager {
     }
 
     @Transactional(readOnly = true)
-    public boolean isHost(final long memberId, final long moimId){
+    public boolean isHost(final long memberId, final long moimId) {
         return moimFinder.isHost(memberId, moimId);
     }
 
@@ -97,13 +97,22 @@ public class MoimManager {
     @Transactional(readOnly = true)
     public List<MoimSimpleResponse> findAllJoinedMoimSimpleResponseByEndStatus(final long memberId, final LocalDate now, final boolean ended) {
         List<Long> joinedMoims = joinedMoimFinder.findMoimIdsByMemberId(memberId);
-        return getMoimSimpleResponses(ended, joinedMoims, now);
+        return getMoimSimpleResponses(joinedMoims, now, ended);
     }
 
     @Transactional(readOnly = true)
-    public List<MoimSimpleResponse> getMoimSimpleResponses(final boolean ended, final List<Long> joinedMoims, final LocalDate now) {
-        if(ended){
-           return moimFinder.findEndedMoimSimpleResponsesByMoimIds(joinedMoims, now);
+    public List<MoimSimpleResponse> findAllHostMoimSimpleResponsesByEndStatus(final long hostMemberId, final LocalDate now, final boolean ended) {
+        List<Long> joinedMoims = joinedMoimFinder.findMoimIdsByMemberId(hostMemberId);
+        List<Long> hostMoims = joinedMoims.stream()
+                .filter(moimId -> moimFinder.isHost(hostMemberId, moimId))
+                .toList();
+        return getMoimSimpleResponses(hostMoims, now, ended);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MoimSimpleResponse> getMoimSimpleResponses(final List<Long> joinedMoims, final LocalDate now, final boolean ended) {
+        if (ended) {
+            return moimFinder.findEndedMoimSimpleResponsesByMoimIds(joinedMoims, now);
         }
         return moimFinder.findInProgressMoimSimpleResponsesByMoimIds(joinedMoims, now);
     }

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimManager.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimManager.java
@@ -1,5 +1,6 @@
 package moim_today.implement.moim.moim;
 
+import moim_today.dto.moim.moim.MoimSimpleResponse;
 import moim_today.global.annotation.Implement;
 import moim_today.implement.meeting.joined_meeting.JoinedMeetingAppender;
 import moim_today.implement.meeting.joined_meeting.JoinedMeetingRemover;
@@ -13,6 +14,7 @@ import moim_today.implement.todo.TodoRemover;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Implement
@@ -90,5 +92,19 @@ public class MoimManager {
     @Transactional(readOnly = true)
     public String getTitleById(final Long moimId) {
         return moimFinder.getTitleById(moimId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MoimSimpleResponse> findAllJoinedMoimSimpleResponseByEndStatus(final long memberId, final LocalDate now, final boolean ended) {
+        List<Long> joinedMoims = joinedMoimFinder.findMoimIdsByMemberId(memberId);
+        return getMoimSimpleResponses(ended, joinedMoims, now);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MoimSimpleResponse> getMoimSimpleResponses(final boolean ended, final List<Long> joinedMoims, final LocalDate now) {
+        if(ended){
+           return moimFinder.findEndedMoimSimpleResponsesByMoimIds(joinedMoims, now);
+        }
+        return moimFinder.findInProgressMoimSimpleResponsesByMoimIds(joinedMoims, now);
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/moim/joined_moim/JoinedMoimJpaRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/moim/joined_moim/JoinedMoimJpaRepository.java
@@ -14,4 +14,6 @@ public interface JoinedMoimJpaRepository extends JpaRepository<JoinedMoimJpaEnti
     void deleteByMoimIdAndMemberId(final long moimId, final long memberId);
 
     boolean existsByMoimIdAndMemberId(final long moimId, final long memberId);
+
+    List<JoinedMoimJpaEntity> findAllByMemberId(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/moim/moim/MoimRepository.java
@@ -7,6 +7,7 @@ import moim_today.dto.moim.moim.MyMoimResponse;
 import moim_today.dto.moim.moim.enums.MoimCategoryDto;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface MoimRepository {
@@ -30,4 +31,8 @@ public interface MoimRepository {
     MoimJpaEntity getByIdWithPessimisticLock(final long moimId);
 
     List<MoimSimpleResponse> searchMoimBySearchParam(final long universityId, final String searchParam);
+
+    List<MoimSimpleResponse> findEndedMoimSimpleResponsesByMoimIds(final List<Long> moimIds, final LocalDate now);
+
+    List<MoimSimpleResponse> findInProgressMoimSimpleResponsesByMoimIds(final List<Long> moimIds, final LocalDate now);
 }

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -40,9 +40,10 @@ public class MoimController {
     @GetMapping("/joined/simple")
     public CollectionResponse<List<MoimSimpleResponse>> findAllMyJoinedMoimSimpleResponse(
             @Login final MemberSession memberSession,
-            @RequestParam final Boolean ended){
+            @RequestParam final Boolean ended,
+            @RequestParam(required = false, defaultValue = "false") final Boolean onlyHost){
         List<MoimSimpleResponse> myMoimSimpleResponses = moimService.findAllMyJoinedMoimSimpleResponse(
-                memberSession.id(), ended
+                memberSession.id(), ended, onlyHost
         );
         return CollectionResponse.from(myMoimSimpleResponses);
     }

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -32,10 +32,21 @@ public class MoimController {
     }
 
     @GetMapping
-    public CollectionResponse<List<MyMoimResponse>> findAllMyMoimResponse(@Login final MemberSession memberSession) {
-        List<MyMoimResponse> myMoimResponses = moimService.findAllMyMoimResponse(memberSession.id());
+    public CollectionResponse<List<MyMoimResponse>> findAllMyJoinedMoimResponse(@Login final MemberSession memberSession) {
+        List<MyMoimResponse> myMoimResponses = moimService.findAllMyJoinedMoimResponse(memberSession.id());
         return CollectionResponse.from(myMoimResponses);
     }
+
+    @GetMapping("/joined/detail")
+    public CollectionResponse<List<MoimSimpleResponse>> findAllMyJoinedMoimSimpleResponse(
+            @Login final MemberSession memberSession,
+            @RequestParam final boolean ended){
+        List<MoimSimpleResponse> myMoimSimpleResponses = moimService.findAllMyJoinedMoimSimpleResponse(
+                memberSession.id(), ended
+        );
+        return CollectionResponse.from(myMoimSimpleResponses);
+    }
+
 
     @PostMapping
     public MoimIdResponse createMoim(@Login final MemberSession memberSession,

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -37,7 +37,7 @@ public class MoimController {
         return CollectionResponse.from(myMoimResponses);
     }
 
-    @GetMapping("/joined/detail")
+    @GetMapping("/joined/simple")
     public CollectionResponse<List<MoimSimpleResponse>> findAllMyJoinedMoimSimpleResponse(
             @Login final MemberSession memberSession,
             @RequestParam final Boolean ended){

--- a/backend/src/main/java/moim_today/presentation/moim/MoimController.java
+++ b/backend/src/main/java/moim_today/presentation/moim/MoimController.java
@@ -40,7 +40,7 @@ public class MoimController {
     @GetMapping("/joined/detail")
     public CollectionResponse<List<MoimSimpleResponse>> findAllMyJoinedMoimSimpleResponse(
             @Login final MemberSession memberSession,
-            @RequestParam final boolean ended){
+            @RequestParam final Boolean ended){
         List<MoimSimpleResponse> myMoimSimpleResponses = moimService.findAllMyJoinedMoimSimpleResponse(
                 memberSession.id(), ended
         );

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -23,7 +23,7 @@ import static moim_today.util.TestConstant.*;
 public class FakeMoimService implements MoimService {
 
     @Override
-    public List<MyMoimResponse> findAllMyMoimResponse(final long memberId) {
+    public List<MyMoimResponse> findAllMyJoinedMoimResponse(final long memberId) {
         MyMoimResponse myMoimResponse1 = MyMoimResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())
@@ -174,6 +174,31 @@ public class FakeMoimService implements MoimService {
 
     @Override
     public List<MoimSimpleResponse> searchMoim(final long universityId, final String searchParam) {
+        MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
+                .moimId(1L)
+                .title(MOIM_TITLE.value())
+                .capacity(CAPACITY.intValue())
+                .currentCount(CURRENT_COUNT.intValue())
+                .imageUrl(MOIM_IMAGE_URL.value())
+                .moimCategory(MoimCategory.STUDY)
+                .displayStatus(DisplayStatus.PUBLIC)
+                .build();
+
+        MoimSimpleResponse moimSimpleResponse2 = MoimSimpleResponse.builder()
+                .moimId(2L)
+                .title(MOIM_TITLE.value())
+                .capacity(CAPACITY.intValue())
+                .currentCount(CURRENT_COUNT.intValue())
+                .imageUrl(MOIM_IMAGE_URL.value())
+                .moimCategory(MoimCategory.STUDY)
+                .displayStatus(DisplayStatus.PUBLIC)
+                .build();
+
+        return List.of(moimSimpleResponse1, moimSimpleResponse2);
+    }
+
+    @Override
+    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended) {
         MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -198,7 +198,9 @@ public class FakeMoimService implements MoimService {
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended, final boolean host) {
+    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId,
+                                                                      final boolean ended,
+                                                                      final boolean onlyHost) {
         MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
+++ b/backend/src/test/java/moim_today/fake_class/moim/FakeMoimService.java
@@ -198,7 +198,7 @@ public class FakeMoimService implements MoimService {
     }
 
     @Override
-    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended) {
+    public List<MoimSimpleResponse> findAllMyJoinedMoimSimpleResponse(final long memberId, final boolean ended, final boolean host) {
         MoimSimpleResponse moimSimpleResponse1 = MoimSimpleResponse.builder()
                 .moimId(1L)
                 .title(MOIM_TITLE.value())

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimFinderTest.java
@@ -568,7 +568,7 @@ class MoimFinderTest extends ImplementTest {
     void searchMoimBySearchParamAndUniversityId() {
         // given1
         long universityId = UNIV_ID.longValue();
-        long otherUniversityId = UNIV_ID.longValue() + 1 ;
+        long otherUniversityId = UNIV_ID.longValue() + 1;
 
         MoimJpaEntity moimA = MoimJpaEntity.builder()
                 .universityId(universityId)
@@ -604,6 +604,80 @@ class MoimFinderTest extends ImplementTest {
         assertThat(blankResponses.size()).isEqualTo(2);
         assertThat(noneResponses.size()).isEqualTo(0);
         assertThat(applemangoResponses.size()).isEqualTo(1);
+    }
+
+    @DisplayName("모임들 중 완료된 모임을 반환한다.")
+    @Test
+    void findEndedMoimSimpleResponsesByMoimIds() {
+        MemberJpaEntity saveMember = saveRandomMember();
+
+        LocalDate localDate1 = LocalDate.of(2023, 5, 12);
+        LocalDate localDate2 = LocalDate.of(2024, 5, 16);
+        LocalDate localDate3 = LocalDate.of(2025, 6, 5);
+
+        MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
+                .memberId(saveMember.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity moimJpaEntity2 = MoimJpaEntity.builder()
+                .memberId(saveMember.getId())
+                .endDate(localDate2)
+                .build();
+        MoimJpaEntity moimJpaEntity3 = MoimJpaEntity.builder()
+                .memberId(saveMember.getId())
+                .endDate(localDate3)
+                .build();
+
+        moimRepository.save(moimJpaEntity1);
+        moimRepository.save(moimJpaEntity2);
+        moimRepository.save(moimJpaEntity3);
+
+        List<Long> moimIds = List.of(moimJpaEntity1.getId(), moimJpaEntity2.getId(), moimJpaEntity3.getId());
+
+        List<MoimSimpleResponse> endedMoims1 = moimFinder.findEndedMoimSimpleResponsesByMoimIds(
+                moimIds, LocalDate.of(2024, 5, 16));
+        List<MoimSimpleResponse> endedMoims2 = moimFinder.findEndedMoimSimpleResponsesByMoimIds(
+                moimIds, LocalDate.of(2025, 6, 4));
+
+        assertThat(endedMoims1.size()).isEqualTo(1);
+        assertThat(endedMoims2.size()).isEqualTo(2);
+    }
+
+    @DisplayName("모임들 중 진행중인 모임을 반환한다.")
+    @Test
+    void findInProgressMoimSimpleResponsesByMoimIds() {
+        MemberJpaEntity saveMember = saveRandomMember();
+
+        LocalDate localDate1 = LocalDate.of(2023, 5, 12);
+        LocalDate localDate2 = LocalDate.of(2024, 5, 16);
+        LocalDate localDate3 = LocalDate.of(2025, 6, 5);
+
+        MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
+                .memberId(saveMember.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity moimJpaEntity2 = MoimJpaEntity.builder()
+                .memberId(saveMember.getId())
+                .endDate(localDate2)
+                .build();
+        MoimJpaEntity moimJpaEntity3 = MoimJpaEntity.builder()
+                .memberId(saveMember.getId())
+                .endDate(localDate3)
+                .build();
+
+        moimRepository.save(moimJpaEntity1);
+        moimRepository.save(moimJpaEntity2);
+        moimRepository.save(moimJpaEntity3);
+
+        List<Long> moimIds = List.of(moimJpaEntity1.getId(), moimJpaEntity2.getId(), moimJpaEntity3.getId());
+
+        List<MoimSimpleResponse> inProgressMoims1 = moimFinder.findInProgressMoimSimpleResponsesByMoimIds(
+                moimIds, LocalDate.of(2024, 5, 16));
+        List<MoimSimpleResponse> inProgressMoims2 = moimFinder.findInProgressMoimSimpleResponsesByMoimIds(
+                moimIds, LocalDate.of(2025, 6, 4));
+
+        assertThat(inProgressMoims1.size()).isEqualTo(2);
+        assertThat(inProgressMoims2.size()).isEqualTo(1);
     }
 
     private MemberJpaEntity saveRandomMember() {

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimManagerTest.java
@@ -75,6 +75,7 @@ class MoimManagerTest extends ImplementTest {
         LocalDate localDate2 = LocalDate.of(2024, 5, 16);
         LocalDate localDate3 = LocalDate.of(2025, 6, 5);
 
+        // given2
         MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
                 .memberId(member1.getId())
                 .endDate(localDate1)
@@ -92,6 +93,7 @@ class MoimManagerTest extends ImplementTest {
         moimRepository.save(moimJpaEntity2);
         moimRepository.save(moimJpaEntity3);
 
+        // given3
         JoinedMoimJpaEntity j1 = JoinedMoimJpaEntity.builder()
                 .memberId(member1.getId())
                 .moimId(moimJpaEntity1.getId())
@@ -109,11 +111,13 @@ class MoimManagerTest extends ImplementTest {
         joinedMoimRepository.save(j2);
         joinedMoimRepository.save(j3);
 
+        // when
         List<MoimSimpleResponse> endedMoims = moimManager.findAllJoinedMoimSimpleResponseByEndStatus(
                 member1.getId(), LocalDate.of(2024, 5, 16), true);
         List<MoimSimpleResponse> inProgressMoims = moimManager.findAllJoinedMoimSimpleResponseByEndStatus(
                 member1.getId(), LocalDate.of(2024, 5, 16), false);
 
+        // then
         assertThat(endedMoims.size()).isEqualTo(1);
         assertThat(inProgressMoims.size()).isEqualTo(2);
     }

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimManagerTest.java
@@ -1,16 +1,22 @@
 package moim_today.implement.moim.moim;
 
+import moim_today.dto.moim.moim.MoimSimpleResponse;
+import moim_today.persistence.entity.member.MemberJpaEntity;
+import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.util.ImplementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static moim_today.util.TestConstant.MEMBER_ID;
+import static moim_today.util.TestConstant.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MoimManagerTest extends ImplementTest {
@@ -53,5 +59,133 @@ class MoimManagerTest extends ImplementTest {
         // then
         long joinedMembersCount =  joinedMoimRepository.findAllJoinedMemberId(savedMoimId).size();
         assertThat(joinedMembersCount).isEqualTo(MOIM_MAXIMUM_PEOPLE);
+    }
+
+    @DisplayName("자신이 참여한 모임들 중 완료 여부에 따라 반환한다.")
+    @Test
+    void findAllJoinedMoimSimpleResponseByEndStatus() {
+        // given1
+        MemberJpaEntity member1 = MemberJpaEntity.builder()
+                .username(USERNAME.value())
+                .build();
+
+        memberRepository.save(member1);
+
+        LocalDate localDate1 = LocalDate.of(2023, 5, 12);
+        LocalDate localDate2 = LocalDate.of(2024, 5, 16);
+        LocalDate localDate3 = LocalDate.of(2025, 6, 5);
+
+        MoimJpaEntity moimJpaEntity1 = MoimJpaEntity.builder()
+                .memberId(member1.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity moimJpaEntity2 = MoimJpaEntity.builder()
+                .memberId(member1.getId())
+                .endDate(localDate2)
+                .build();
+        MoimJpaEntity moimJpaEntity3 = MoimJpaEntity.builder()
+                .memberId(member1.getId())
+                .endDate(localDate3)
+                .build();
+
+        moimRepository.save(moimJpaEntity1);
+        moimRepository.save(moimJpaEntity2);
+        moimRepository.save(moimJpaEntity3);
+
+        JoinedMoimJpaEntity j1 = JoinedMoimJpaEntity.builder()
+                .memberId(member1.getId())
+                .moimId(moimJpaEntity1.getId())
+                .build();
+        JoinedMoimJpaEntity j2 = JoinedMoimJpaEntity.builder()
+                .memberId(member1.getId())
+                .moimId(moimJpaEntity2.getId())
+                .build();
+        JoinedMoimJpaEntity j3 = JoinedMoimJpaEntity.builder()
+                .memberId(member1.getId())
+                .moimId(moimJpaEntity3.getId())
+                .build();
+
+        joinedMoimRepository.save(j1);
+        joinedMoimRepository.save(j2);
+        joinedMoimRepository.save(j3);
+
+        List<MoimSimpleResponse> endedMoims = moimManager.findAllJoinedMoimSimpleResponseByEndStatus(
+                member1.getId(), LocalDate.of(2024, 5, 16), true);
+        List<MoimSimpleResponse> inProgressMoims = moimManager.findAllJoinedMoimSimpleResponseByEndStatus(
+                member1.getId(), LocalDate.of(2024, 5, 16), false);
+
+        assertThat(endedMoims.size()).isEqualTo(1);
+        assertThat(inProgressMoims.size()).isEqualTo(2);
+    }
+    @DisplayName("다른 멤버의 모임들을 제외한 자신이 참여한 모임들 중 완료 여부에 따라 반환한다.")
+    @Test
+    void findAllJoinedMoimSimpleResponseExceptOtherMembers() {
+        // given
+        MemberJpaEntity me = MemberJpaEntity.builder()
+                .username(USERNAME.value())
+                .build();
+        MemberJpaEntity other = MemberJpaEntity.builder()
+                .username(USERNAME.value()+"1")
+                .build();
+
+        memberRepository.save(me);
+        memberRepository.save(other);
+
+        LocalDate localDate1 = LocalDate.of(2023, 5, 12);
+        LocalDate localDate2 = LocalDate.of(2024, 5, 16);
+
+        MoimJpaEntity myMoim1 = MoimJpaEntity.builder()
+                .memberId(me.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity myMoim2 = MoimJpaEntity.builder()
+                .memberId(me.getId())
+                .endDate(localDate2)
+                .build();
+        MoimJpaEntity otherMoim1 = MoimJpaEntity.builder()
+                .memberId(other.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity otherMoim2 = MoimJpaEntity.builder()
+                .memberId(other.getId())
+                .endDate(localDate2)
+                .build();
+
+        moimRepository.save(myMoim1);
+        moimRepository.save(myMoim2);
+        moimRepository.save(otherMoim1);
+        moimRepository.save(otherMoim2);
+
+        JoinedMoimJpaEntity j1 = JoinedMoimJpaEntity.builder()
+                .memberId(me.getId())
+                .moimId(myMoim1.getId())
+                .build();
+        JoinedMoimJpaEntity j2 = JoinedMoimJpaEntity.builder()
+                .memberId(me.getId())
+                .moimId(myMoim2.getId())
+                .build();
+        JoinedMoimJpaEntity j3 = JoinedMoimJpaEntity.builder()
+                .memberId(other.getId())
+                .moimId(otherMoim1.getId())
+                .build();
+        JoinedMoimJpaEntity j4 = JoinedMoimJpaEntity.builder()
+                .memberId(other.getId())
+                .moimId(otherMoim2.getId())
+                .build();
+
+        joinedMoimRepository.save(j1);
+        joinedMoimRepository.save(j2);
+        joinedMoimRepository.save(j3);
+        joinedMoimRepository.save(j4);
+
+        // when
+        List<MoimSimpleResponse> myEndedMoims = moimManager.findAllJoinedMoimSimpleResponseByEndStatus(
+                me.getId(), LocalDate.of(2023,5,12), true);
+        List<MoimSimpleResponse> myInProgressMoims = moimManager.findAllJoinedMoimSimpleResponseByEndStatus(
+                me.getId(), LocalDate.of(2023, 5, 12), false);
+
+        // then
+        assertThat(myEndedMoims.size()).isEqualTo(0);
+        assertThat(myInProgressMoims.size()).isEqualTo(2);
     }
 }

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimManagerTest.java
@@ -188,4 +188,86 @@ class MoimManagerTest extends ImplementTest {
         assertThat(myEndedMoims.size()).isEqualTo(0);
         assertThat(myInProgressMoims.size()).isEqualTo(2);
     }
+
+    @DisplayName("자신이 호스트인 모임들의 정보만 완료 여부에 따라 가져온다")
+    @Test
+    void findAllHostMoimSimpleResponsesByEndStatus() {
+        // given
+        MemberJpaEntity me = MemberJpaEntity.builder()
+                .username(USERNAME.value())
+                .build();
+        MemberJpaEntity other = MemberJpaEntity.builder()
+                .username(USERNAME.value()+"1")
+                .build();
+
+        memberRepository.save(me);
+        memberRepository.save(other);
+
+        LocalDate localDate1 = LocalDate.of(2023, 5, 12);
+        LocalDate localDate2 = LocalDate.of(2024, 5, 16);
+
+        MoimJpaEntity myMoim1 = MoimJpaEntity.builder()
+                .memberId(me.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity myMoim2 = MoimJpaEntity.builder()
+                .memberId(me.getId())
+                .endDate(localDate2)
+                .build();
+        MoimJpaEntity otherMoim1 = MoimJpaEntity.builder()
+                .memberId(other.getId())
+                .endDate(localDate1)
+                .build();
+        MoimJpaEntity otherMoim2 = MoimJpaEntity.builder()
+                .memberId(other.getId())
+                .endDate(localDate2)
+                .build();
+
+        moimRepository.save(myMoim1);
+        moimRepository.save(myMoim2);
+        moimRepository.save(otherMoim1);
+        moimRepository.save(otherMoim2);
+
+        JoinedMoimJpaEntity j1 = JoinedMoimJpaEntity.builder()
+                .memberId(me.getId())
+                .moimId(myMoim1.getId())
+                .build();
+        JoinedMoimJpaEntity j2 = JoinedMoimJpaEntity.builder()
+                .memberId(me.getId())
+                .moimId(myMoim2.getId())
+                .build();
+        JoinedMoimJpaEntity j3 = JoinedMoimJpaEntity.builder()
+                .memberId(other.getId())
+                .moimId(otherMoim1.getId())
+                .build();
+        JoinedMoimJpaEntity j4 = JoinedMoimJpaEntity.builder()
+                .memberId(other.getId())
+                .moimId(otherMoim2.getId())
+                .build();
+        JoinedMoimJpaEntity j5 = JoinedMoimJpaEntity.builder()
+                .memberId(me.getId())
+                .moimId(otherMoim1.getId())
+                .build();
+        JoinedMoimJpaEntity j6 = JoinedMoimJpaEntity.builder()
+                .memberId(me.getId())
+                .moimId(otherMoim2.getId())
+                .build();
+
+        joinedMoimRepository.save(j1);
+        joinedMoimRepository.save(j2);
+        joinedMoimRepository.save(j3);
+        joinedMoimRepository.save(j4);
+        joinedMoimRepository.save(j5);
+        joinedMoimRepository.save(j6);
+
+        // when
+        List<MoimSimpleResponse> myEndedMoims = moimManager.findAllHostMoimSimpleResponsesByEndStatus(
+                me.getId(), LocalDate.of(2023,5,12), true);
+        List<MoimSimpleResponse> myInProgressMoims = moimManager.findAllHostMoimSimpleResponsesByEndStatus(
+                me.getId(), LocalDate.of(2023, 5, 12), false);
+
+        // then
+        assertThat(myEndedMoims.size()).isEqualTo(0);
+        assertThat(myInProgressMoims.size()).isEqualTo(2);
+    }
 }

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -52,7 +52,7 @@ class MoimControllerTest extends ControllerTest {
                 .andDo(document("로그인한 회원이 참여한 모임 리스트 조회",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("모임")
-                                .summary("로그인한 회원이 참여한 모임 리스트 조회")
+                                .summary("로그인한 회원이 참여한 모임 리스트 간단한 정보 조회")
                                 .responseFields(
                                         fieldWithPath("data[0].moimId").type(NUMBER).description("모임 Id"),
                                         fieldWithPath("data[0].title").type(STRING).description("모임명")
@@ -809,7 +809,7 @@ class MoimControllerTest extends ControllerTest {
                         )));
     }
 
-    @DisplayName("자신이 참여한 모임의 모임들을 완료 여부에 따라 카드 정보로 반환한다")
+    @DisplayName("로그인한 회원이 참여한 모임들을 완료 여부에 따라 카드 정보로 반환한다")
     @Test
     void findAllMyJoinedMoimSimpleResponse() throws Exception {
 
@@ -819,9 +819,9 @@ class MoimControllerTest extends ControllerTest {
                 .andDo(document("자신이 참여한 모임 리스트를 완료 여부로 조회 성공",
                                 resource(ResourceSnippetParameters.builder()
                                         .tag("모임")
-                                        .summary("자신이 참여한 모임 리스트 정보 조회")
+                                        .summary("로그인한 회원이 참여한 모임 리스트 자세한 정보 조회")
                                         .queryParameters(
-                                                parameterWithName("ended").description("완료된 모임을 찾을 지 여부")
+                                                parameterWithName("ended").description("완료된 모임을 찾을 지 여부 - [true, false]")
                                         )
                                         .responseFields(
                                                 fieldWithPath("data[0].moimId").type(NUMBER).description("모임 Id"),

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -813,7 +813,7 @@ class MoimControllerTest extends ControllerTest {
     @Test
     void findAllMyJoinedMoimSimpleResponse() throws Exception {
 
-        mockMvc.perform(get("/api/moims/joined/detail")
+        mockMvc.perform(get("/api/moims/joined/simple")
                         .queryParam("ended", "false"))
                 .andExpect(status().isOk())
                 .andDo(document("자신이 참여한 모임 리스트를 완료 여부로 조회 성공",

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -808,4 +808,33 @@ class MoimControllerTest extends ControllerTest {
                                 .build()
                         )));
     }
+
+    @DisplayName("자신이 참여한 모임의 모임들을 완료 여부에 따라 카드 정보로 반환한다")
+    @Test
+    void findAllMyJoinedMoimSimpleResponse() throws Exception {
+
+        mockMvc.perform(get("/api/moims/joined/detail")
+                        .queryParam("ended", "false"))
+                .andExpect(status().isOk())
+                .andDo(document("자신이 참여한 모임 리스트를 완료 여부로 조회 성공",
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("모임")
+                                        .summary("자신이 참여한 모임 리스트 정보 조회")
+                                        .queryParameters(
+                                                parameterWithName("ended").description("완료된 모임을 찾을 지 여부")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("data[0].moimId").type(NUMBER).description("모임 Id"),
+                                                fieldWithPath("data[0].title").type(STRING).description("모임명"),
+                                                fieldWithPath("data[0].capacity").type(NUMBER).description("모집 인원"),
+                                                fieldWithPath("data[0].currentCount").type(NUMBER).description("현재 인원"),
+                                                fieldWithPath("data[0].imageUrl").type(STRING).description("모임 사진 URL"),
+                                                fieldWithPath("data[0].moimCategory").type(VARIES).description(String.format("카테고리 - %s",
+                                                        EnumDocsUtils.getEnumNames(MoimCategory.class))),
+                                                fieldWithPath("data[0].displayStatus").type(VARIES).description(String.format("공개 여부 - %s",
+                                                        EnumDocsUtils.getEnumNames(DisplayStatus.class)))
+                                        )
+                                        .build())
+                        ));
+    }
 }

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -837,4 +837,35 @@ class MoimControllerTest extends ControllerTest {
                                         .build())
                         ));
     }
+
+    @DisplayName("로그인한 회원이 호스트인 모임들을 완료 여부에 따라 카드 정보로 반환한다")
+    @Test
+    void findAllHostMoimSimpleResponse() throws Exception {
+
+        mockMvc.perform(get("/api/moims/joined/simple")
+                        .queryParam("ended", "false")
+                        .queryParam("onlyHost","true"))
+                .andExpect(status().isOk())
+                .andDo(document("자신이 호스트인 모임 리스트를 완료 여부로 조회 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("모임")
+                                .summary("로그인한 회원이 호스트인 모임 리스트 자세한 정보 조회")
+                                .queryParameters(
+                                        parameterWithName("ended").description("완료된 모임을 찾을 지 여부 - [true, false]"),
+                                        parameterWithName("onlyHost").optional().description("자신이 호스트인 모임만 찾을 지 여부 - [true, false] , default : false")
+                                )
+                                .responseFields(
+                                        fieldWithPath("data[0].moimId").type(NUMBER).description("모임 Id"),
+                                        fieldWithPath("data[0].title").type(STRING).description("모임명"),
+                                        fieldWithPath("data[0].capacity").type(NUMBER).description("모집 인원"),
+                                        fieldWithPath("data[0].currentCount").type(NUMBER).description("현재 인원"),
+                                        fieldWithPath("data[0].imageUrl").type(STRING).description("모임 사진 URL"),
+                                        fieldWithPath("data[0].moimCategory").type(VARIES).description(String.format("카테고리 - %s",
+                                                EnumDocsUtils.getEnumNames(MoimCategory.class))),
+                                        fieldWithPath("data[0].displayStatus").type(VARIES).description(String.format("공개 여부 - %s",
+                                                EnumDocsUtils.getEnumNames(DisplayStatus.class)))
+                                )
+                                .build())
+                ));
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #169 

## 📝작업 내용

> 자신이 참여한 모임들을 완료 여부에 따라 조회하고, 정보를 반환하는 기능 추가
> 자신이 호스트인 모임들을 완료 여부에 따라 조회하고, 정보를 반환하는 기능 추가

## 리뷰 요청

> moim api 에서 자신이 참여한 모임들을 간단한 모임 정보로 조회하는 것이 있는데, api 이름이 헷갈릴 소지가 있다고 생각합니당. 저는 api/moims/joined/simple 인데, 자신이 참여한 모임 조회는 api/moims 입니다. 여기 뒤에 api/moims/joined 로 수정하는 것은 어떨까요?

close #169 