### PR TITLE
[BE] 멤버가 모임에서 나갈시, 모임의 현재 인원 수정 로직 추가 및 리팩토링

### DIFF
--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -69,11 +69,13 @@ public class MoimServiceImpl implements MoimService{
         this.moimManager = moimManager;
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<MyMoimResponse> findAllMyJoinedMoimResponse(final long memberId) {
         return moimFinder.findAllMyMoimResponse(memberId);
     }
 
+    @Transactional
     @Override
     public MoimIdResponse createMoim(final long memberId, final long universityId,
                            final MoimCreateRequest moimCreateRequest) {
@@ -82,12 +84,14 @@ public class MoimServiceImpl implements MoimService{
         return MoimIdResponse.from(moim.getId());
     }
 
+    @Transactional(readOnly = true)
     @Override
     public MoimImageResponse uploadMoimImage(final MultipartFile file) {
         String imageUrl = fileUploader.uploadFile(MOIM_IMAGE.value(), file);
         return MoimImageResponse.from(imageUrl);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public MoimDetailResponse getMoimDetail(final long moimId,
                                             final String viewedMoimsCookieByUrlEncoded,
@@ -97,6 +101,7 @@ public class MoimServiceImpl implements MoimService{
         return MoimDetailResponse.from(moimJpaEntity);
     }
 
+    @Transactional
     @Override
     public void updateMoim(final long memberId, final MoimUpdateRequest moimUpdateRequest) {
         moimUpdater.updateMoim(memberId, moimUpdateRequest);
@@ -118,6 +123,7 @@ public class MoimServiceImpl implements MoimService{
         scheduleRemover.deleteAllByMeetingIdIn(meetingIds);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public MoimMemberTabResponse findMoimMembers(final long memberId, final long moimId) {
         MoimJpaEntity moimJpaEntity = moimFinder.getById(moimId);

--- a/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/moim/moim/MoimServiceImpl.java
@@ -69,7 +69,6 @@ public class MoimServiceImpl implements MoimService{
         this.moimManager = moimManager;
     }
 
-    @Transactional(readOnly = true)
     @Override
     public List<MyMoimResponse> findAllMyJoinedMoimResponse(final long memberId) {
         return moimFinder.findAllMyMoimResponse(memberId);
@@ -84,14 +83,12 @@ public class MoimServiceImpl implements MoimService{
         return MoimIdResponse.from(moim.getId());
     }
 
-    @Transactional(readOnly = true)
     @Override
     public MoimImageResponse uploadMoimImage(final MultipartFile file) {
         String imageUrl = fileUploader.uploadFile(MOIM_IMAGE.value(), file);
         return MoimImageResponse.from(imageUrl);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public MoimDetailResponse getMoimDetail(final long moimId,
                                             final String viewedMoimsCookieByUrlEncoded,
@@ -101,7 +98,6 @@ public class MoimServiceImpl implements MoimService{
         return MoimDetailResponse.from(moimJpaEntity);
     }
 
-    @Transactional
     @Override
     public void updateMoim(final long memberId, final MoimUpdateRequest moimUpdateRequest) {
         moimUpdater.updateMoim(memberId, moimUpdateRequest);
@@ -123,7 +119,6 @@ public class MoimServiceImpl implements MoimService{
         scheduleRemover.deleteAllByMeetingIdIn(meetingIds);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public MoimMemberTabResponse findMoimMembers(final long memberId, final long moimId) {
         MoimJpaEntity moimJpaEntity = moimFinder.getById(moimId);
@@ -137,7 +132,6 @@ public class MoimServiceImpl implements MoimService{
         return MoimMemberTabResponse.of(isHostRequest, moimMemberResponses);
     }
 
-    @Transactional
     @Override
     public void kickMember(final long requestMemberId, final MoimMemberKickRequest moimMemberKickRequest) {
         long moimId = moimMemberKickRequest.moimId();
@@ -150,7 +144,6 @@ public class MoimServiceImpl implements MoimService{
         moimManager.deleteMemberFromMoim(deleteMemberId, moimId);
     }
 
-    @Transactional
     @Override
     public void deleteMember(final long deleteMemberId, final MoimMemberDeleteRequest moimMemberDeleteRequest) {
         long moimId = moimMemberDeleteRequest.moimId();

--- a/backend/src/main/java/moim_today/global/constant/NumberConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/NumberConstant.java
@@ -13,6 +13,9 @@ public enum NumberConstant {
     VIEW_COUNT_OF_ONE(1),
     DEFAULT_JOINED_MOIM_PAGE_SIZE(4),
 
+    PLUS_ONE(1),
+    MINUS_ONE(-1),
+
     SCHEDULE_MEETING_ID(0),
     SCHEDULE_MOIM_ID(0),
     SCHEDULE_COLOR_START_COUNT(0),

--- a/backend/src/main/java/moim_today/implement/moim/joined_moim/JoinedMoimAppender.java
+++ b/backend/src/main/java/moim_today/implement/moim/joined_moim/JoinedMoimAppender.java
@@ -3,7 +3,6 @@ package moim_today.implement.moim.joined_moim;
 import moim_today.global.annotation.Implement;
 import moim_today.implement.moim.moim.MoimFinder;
 import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
-import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.moim.joined_moim.JoinedMoimRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,9 +20,6 @@ public class JoinedMoimAppender {
 
     @Transactional
     public void createJoinedMoim(final long memberId, final long moimId) {
-        MoimJpaEntity findMoim = moimFinder.getByIdWithPessimisticLock(moimId);
-        findMoim.updateCurrentCount(1);
-
         JoinedMoimJpaEntity joinedMoimJpaEntity = JoinedMoimJpaEntity.of(memberId, moimId);
 
         joinedMoimRepository.save(joinedMoimJpaEntity);

--- a/backend/src/main/java/moim_today/implement/moim/moim/MoimUpdater.java
+++ b/backend/src/main/java/moim_today/implement/moim/moim/MoimUpdater.java
@@ -51,4 +51,10 @@ public class MoimUpdater {
             viewedMoimsCookie.addViewedMoimsCookieInCookie(response, objectMapper);
         }
     }
+
+    @Transactional
+    public void updateMoimCurrentCount(final long moimId, final int value) {
+        MoimJpaEntity findMoim = moimFinder.getByIdWithPessimisticLock(moimId);
+        findMoim.addToCurrentCount(value);
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/entity/moim/moim/MoimJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/moim/moim/MoimJpaEntity.java
@@ -11,7 +11,6 @@ import moim_today.global.base_entity.BaseTimeEntity;
 import moim_today.global.error.ForbiddenException;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static moim_today.global.constant.MoimConstant.DEFAULT_MOIM_IMAGE_URL;
 import static moim_today.global.constant.MoimConstant.DEFAULT_MOIM_PASSWORD;
@@ -108,7 +107,7 @@ public class MoimJpaEntity extends BaseTimeEntity {
         updateImageUrl(moimUpdateRequest.imageUrl());
     }
 
-    public void updateCurrentCount(final int plusCount){
+    public void addToCurrentCount(final int plusCount){
         this.currentCount += plusCount;
     }
 

--- a/backend/src/test/java/moim_today/implement/moim/joined_moim/JoinedMoimAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/joined_moim/JoinedMoimAppenderTest.java
@@ -19,7 +19,6 @@ class JoinedMoimAppenderTest extends ImplementTest {
     void createJoinedMoimTest() {
         //given
         MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
-                .currentCount(0)
                 .build();
 
         moimRepository.save(moimJpaEntity);
@@ -33,6 +32,5 @@ class JoinedMoimAppenderTest extends ImplementTest {
         //then
         assertThat(joinedMoimRepository.count()).isEqualTo(1L);
         assertThat(joinedMoimRepository.isJoining(moimId, memberId)).isTrue();
-        assertThat(findMoim.getCurrentCount()).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/moim_today/implement/moim/moim/MoimUpdaterTest.java
+++ b/backend/src/test/java/moim_today/implement/moim/moim/MoimUpdaterTest.java
@@ -17,12 +17,11 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static java.util.Objects.*;
+import static java.util.Objects.requireNonNull;
 import static moim_today.global.constant.MoimConstant.VIEWED_MOIM_COOKIE_NAME;
 import static moim_today.global.constant.exception.MoimExceptionConstant.ORGANIZER_FORBIDDEN_ERROR;
 import static moim_today.util.TestConstant.*;
@@ -223,15 +222,15 @@ class MoimUpdaterTest extends ImplementTest {
         assertThat(m.getCurrentCount()).isEqualTo(1);
     }
 
-    @DisplayName("모임의 현재 인원을 2명이 동시에 1씩 증가시켜도 2로 업데이트 되어야한다.")
+    @DisplayName("모임의 현재 인원을 5명이 동시에 1씩 증가시켜도 5로 업데이트 되어야한다.")
     @Test
     void updateConcurrentMoimCurrentCount() throws Exception{
         // given
-        final int TWO_PEOPLE = 2;
-        final int MOIM_MAXIMUM_PEOPLE = 2;
+        final int FIVE_PEOPLE = 5;
+        final int MOIM_MAXIMUM_PEOPLE = 10;
 
-        ExecutorService executorService = Executors.newFixedThreadPool(TWO_PEOPLE);
-        CountDownLatch latch = new CountDownLatch(TWO_PEOPLE);
+        ExecutorService executorService = Executors.newFixedThreadPool(FIVE_PEOPLE);
+        CountDownLatch latch = new CountDownLatch(FIVE_PEOPLE);
 
         MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
                 .capacity(MOIM_MAXIMUM_PEOPLE)
@@ -241,7 +240,7 @@ class MoimUpdaterTest extends ImplementTest {
         MoimJpaEntity savedMoim = moimRepository.save(moimJpaEntity);
 
         // when
-        for (int i = 0; i < TWO_PEOPLE; i++) {
+        for (int i = 0; i < FIVE_PEOPLE; i++) {
             executorService.submit(() -> {
                 try {
                     moimUpdater.updateMoimCurrentCount(savedMoim.getId(), 1);
@@ -255,6 +254,6 @@ class MoimUpdaterTest extends ImplementTest {
         MoimJpaEntity resultMoim = moimRepository.getById(savedMoim.getId());
 
         // then
-        assertThat(resultMoim.getCurrentCount()).isEqualTo(MOIM_MAXIMUM_PEOPLE);
+        assertThat(resultMoim.getCurrentCount()).isEqualTo(FIVE_PEOPLE);
     }
 }

--- a/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/moim/MoimControllerTest.java
@@ -382,7 +382,7 @@ class MoimControllerTest extends ControllerTest {
                 .andDo(document("모임 멤버 삭제 성공",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("모임")
-                                .summary("모임에서 멤버 삭제")
+                                .summary("모임에서 멤버가 탈퇴한다")
                                 .requestFields(
                                         fieldWithPath("moimId").type(NUMBER).description("탈퇴할 모임 ID")
                                 )


### PR DESCRIPTION
## 📝작업 내용

> 모임에서 멤버가 나갈 시, 현재 모임의 참여 인원을 줄이는 로직 추가
모임의 현재 참여 인원을 업데이트 하는 로직을 분리

## 💬리뷰 요구사항(선택)

> delete 부분이 로직의 긴 흐름을 manager 로 묶거나, 더 좋은 방법을 찾아보고 적용할 수 있도록 해보겠습니다. 현재 로직은 여러 도메인을 건드리는 만큼 흐름이 길다고 생각되네요