### PR TITLE
[BE] 투두를 조회했을 때 데이터 포맷과 정렬 수정

### DIFF
--- a/backend/src/main/java/moim_today/application/todo/TodoService.java
+++ b/backend/src/main/java/moim_today/application/todo/TodoService.java
@@ -9,10 +9,11 @@ public interface TodoService {
 
     TodoCreateResponse createTodo(final long memberId, final TodoCreateRequest todoCreateRequest);
 
-    List<MemberTodoResponse> findAllMembersTodosInMoim(final long memberId,
-                                                       final long moimId,
-                                                       final YearMonth startDate,
-                                                       final int months);
+    List<MemberTodoResponse> findMembersTodosInMoim(final long requestMemberId,
+                                                    final long memberId,
+                                                    final long moimId,
+                                                    final YearMonth startDate,
+                                                    final int months);
 
     TodoUpdateResponse updateTodo(final long memberId, final TodoUpdateRequest todoUpdateRequest);
 
@@ -20,8 +21,8 @@ public interface TodoService {
 
     TodoResponse getById(final long todoId);
 
-    List<MemberMoimTodoResponse> findAllMembersTodos(final long memberId, final YearMonth startDate, final int months);
+    List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth startDate, final int months);
 
-    MemberMoimTodoResponse findMemberTodosInMoim(final long memberId, final Long moimId, final YearMonth startDate,
-                                                 final int months);
+    MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth startDate,
+                                                     final int months);
 }

--- a/backend/src/main/java/moim_today/application/todo/TodoService.java
+++ b/backend/src/main/java/moim_today/application/todo/TodoService.java
@@ -21,8 +21,10 @@ public interface TodoService {
 
     TodoResponse getById(final long todoId);
 
-    List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth startDate, final int months);
+    List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth requestDate, final int months);
 
-    MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth startDate,
+    MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth requestDate,
                                                      final int months);
+
+    TodoUpdateResponse updateTodoProgress(final long memberId, final TodoProgressUpdateRequest todoProgressUpdateRequest);
 }

--- a/backend/src/main/java/moim_today/application/todo/TodoServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/todo/TodoServiceImpl.java
@@ -48,7 +48,7 @@ public class TodoServiceImpl implements TodoService {
         List<Long> moimIds = joinedMoimManager.findMoimIdsByMemberId(memberId);
         return moimIds.stream()
                 .map(moimId -> findMemberMoimTodosInMoim(memberId, moimId, requestDate, months))
-                .filter(memberMoimTodoResponse -> !memberMoimTodoResponse.todoResponses().isEmpty())
+                .filter(memberMoimTodoResponse -> !memberMoimTodoResponse.todoGroupByDates().isEmpty())
                 .toList();
     }
 
@@ -88,11 +88,7 @@ public class TodoServiceImpl implements TodoService {
                                                             final int months) {
         List<TodoResponse> todoResponses = todoManager.findMemberTodosInMoim(memberId, moimId, requestDate, months);
         String moimTitle = moimManager.getTitleById(moimId);
-        return MemberMoimTodoResponse.builder()
-                .moimId(moimId)
-                .moimTitle(moimTitle)
-                .todoResponses(todoResponses)
-                .build();
+        return MemberMoimTodoResponse.of(moimId, moimTitle, todoResponses);
     }
 
     @Override

--- a/backend/src/main/java/moim_today/application/todo/TodoServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/todo/TodoServiceImpl.java
@@ -1,5 +1,6 @@
 package moim_today.application.todo;
 
+import moim_today.domain.todo.enums.TodoProgress;
 import moim_today.dto.todo.*;
 import moim_today.implement.moim.joined_moim.JoinedMoimFinder;
 import moim_today.implement.moim.joined_moim.JoinedMoimManager;
@@ -43,10 +44,10 @@ public class TodoServiceImpl implements TodoService {
     }
 
     @Override
-    public List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth startDate, final int months) {
+    public List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth requestDate, final int months) {
         List<Long> moimIds = joinedMoimManager.findMoimIdsByMemberId(memberId);
         return moimIds.stream()
-                .map(moimId -> findMemberMoimTodosInMoim(memberId, moimId, startDate, months))
+                .map(moimId -> findMemberMoimTodosInMoim(memberId, moimId, requestDate, months))
                 .filter(memberMoimTodoResponse -> !memberMoimTodoResponse.todoResponses().isEmpty())
                 .toList();
     }
@@ -83,14 +84,21 @@ public class TodoServiceImpl implements TodoService {
     }
 
     @Override
-    public MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth startDate,
+    public MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth requestDate,
                                                             final int months) {
-        List<TodoResponse> todoResponses = todoManager.findMemberTodosInMoim(memberId, moimId, startDate, months);
+        List<TodoResponse> todoResponses = todoManager.findMemberTodosInMoim(memberId, moimId, requestDate, months);
         String moimTitle = moimManager.getTitleById(moimId);
         return MemberMoimTodoResponse.builder()
                 .moimId(moimId)
                 .moimTitle(moimTitle)
                 .todoResponses(todoResponses)
                 .build();
+    }
+
+    @Override
+    public TodoUpdateResponse updateTodoProgress(final long memberId, final TodoProgressUpdateRequest todoProgressUpdateRequest) {
+        long todoId = todoProgressUpdateRequest.todoId();
+        TodoProgress todoProgress = todoProgressUpdateRequest.todoProgress();
+        return todoManager.updateTodoProgress(memberId, todoId, todoProgress);
     }
 }

--- a/backend/src/main/java/moim_today/domain/todo/TodoContents.java
+++ b/backend/src/main/java/moim_today/domain/todo/TodoContents.java
@@ -1,0 +1,10 @@
+package moim_today.domain.todo;
+
+import moim_today.domain.todo.enums.TodoProgress;
+
+public record TodoContents(
+        long todoId,
+        String contents,
+        TodoProgress todoProgress
+) {
+}

--- a/backend/src/main/java/moim_today/domain/todo/TodoGroupByDate.java
+++ b/backend/src/main/java/moim_today/domain/todo/TodoGroupByDate.java
@@ -1,0 +1,31 @@
+package moim_today.domain.todo;
+
+import moim_today.dto.todo.TodoResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record TodoGroupByDate(
+        LocalDate todoDate,
+        List<TodoContents> todoContents
+) {
+
+    private static Map<LocalDate, List<TodoResponse>> groupedByDate(final List<TodoResponse> todos) {
+        return todos.stream()
+                .collect(Collectors.groupingBy(TodoResponse::todoDate));
+    }
+
+    public static List<TodoGroupByDate> todoGroupByDates(final List<TodoResponse> todos){
+        Map<LocalDate, List<TodoResponse>> todoGroupByDates = groupedByDate(todos);
+        return todoGroupByDates.entrySet().stream()
+                .map(entry -> new TodoGroupByDate(
+                        entry.getKey(),
+                        entry.getValue().stream()
+                                .map(todo -> new TodoContents(todo.todoId(), todo.contents(), todo.todoProgress()))
+                                .toList()
+                ))
+                .toList();
+    }
+}

--- a/backend/src/main/java/moim_today/domain/todo/TodoGroupByDate.java
+++ b/backend/src/main/java/moim_today/domain/todo/TodoGroupByDate.java
@@ -20,6 +20,7 @@ public record TodoGroupByDate(
     public static List<TodoGroupByDate> todoGroupByDates(final List<TodoResponse> todos){
         Map<LocalDate, List<TodoResponse>> todoGroupByDates = groupedByDate(todos);
         return todoGroupByDates.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> new TodoGroupByDate(
                         entry.getKey(),
                         entry.getValue().stream()

--- a/backend/src/main/java/moim_today/dto/todo/MemberMoimTodoResponse.java
+++ b/backend/src/main/java/moim_today/dto/todo/MemberMoimTodoResponse.java
@@ -1,6 +1,7 @@
 package moim_today.dto.todo;
 
 import lombok.Builder;
+import moim_today.domain.todo.TodoGroupByDate;
 
 import java.util.List;
 
@@ -8,6 +9,15 @@ import java.util.List;
 public record MemberMoimTodoResponse(
         long moimId,
         String moimTitle,
-        List<TodoResponse> todoResponses
+        List<TodoGroupByDate> todoGroupByDates
 ) {
+
+    public static MemberMoimTodoResponse of(final long moimId, final String moimTitle, final List<TodoResponse> todoResponses){
+        List<TodoGroupByDate> todoGroupByDates = TodoGroupByDate.todoGroupByDates(todoResponses);
+        return MemberMoimTodoResponse.builder()
+                .moimId(moimId)
+                .moimTitle(moimTitle)
+                .todoGroupByDates(todoGroupByDates)
+                .build();
+    }
 }

--- a/backend/src/main/java/moim_today/dto/todo/MemberTodoResponse.java
+++ b/backend/src/main/java/moim_today/dto/todo/MemberTodoResponse.java
@@ -1,19 +1,21 @@
 package moim_today.dto.todo;
 
 import lombok.Builder;
+import moim_today.domain.todo.TodoGroupByDate;
 
 import java.util.List;
 
 @Builder
 public record MemberTodoResponse(
         long memberId,
-        List<TodoResponse> todoResponses
+        List<TodoGroupByDate> todoGroupByDates
 ) {
 
     public static MemberTodoResponse of(final long memberId, final List<TodoResponse> todoResponses){
+        List<TodoGroupByDate> todoGroupByDates = TodoGroupByDate.todoGroupByDates(todoResponses);
         return MemberTodoResponse.builder()
                 .memberId(memberId)
-                .todoResponses(todoResponses)
+                .todoGroupByDates(todoGroupByDates)
                 .build();
     }
 }

--- a/backend/src/main/java/moim_today/dto/todo/TodoProgressUpdateRequest.java
+++ b/backend/src/main/java/moim_today/dto/todo/TodoProgressUpdateRequest.java
@@ -1,0 +1,9 @@
+package moim_today.dto.todo;
+
+import moim_today.domain.todo.enums.TodoProgress;
+
+public record TodoProgressUpdateRequest(
+        long todoId,
+        TodoProgress todoProgress
+) {
+}

--- a/backend/src/main/java/moim_today/implement/moim/joined_moim/JoinedMoimFinder.java
+++ b/backend/src/main/java/moim_today/implement/moim/joined_moim/JoinedMoimFinder.java
@@ -54,6 +54,7 @@ public class JoinedMoimFinder {
         return joinedMoimRepository.isJoining(moimId, memberId);
     }
 
+    @Transactional(readOnly = true)
     public List<Long> findMoimIdsByMemberId(final long memberId) {
         return joinedMoimRepository.findMoimIdsByMemberId(memberId);
     }

--- a/backend/src/main/java/moim_today/implement/todo/TodoFinder.java
+++ b/backend/src/main/java/moim_today/implement/todo/TodoFinder.java
@@ -4,6 +4,7 @@ import moim_today.dto.todo.TodoResponse;
 import moim_today.global.annotation.Implement;
 import moim_today.persistence.entity.todo.TodoJpaEntity;
 import moim_today.persistence.repository.todo.TodoRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,6 +18,7 @@ public class TodoFinder {
         this.todoRepository = todoRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<TodoResponse> findAllByDateRange(final long memberId,
                                                  final long moimId,
                                                  final LocalDate startDate,
@@ -24,6 +26,7 @@ public class TodoFinder {
         return todoRepository.findAllByDateRange(memberId, moimId, startDate, endDate);
     }
 
+    @Transactional(readOnly = true)
     public TodoJpaEntity getById(final long todoId){
         return todoRepository.getById(todoId);
     }

--- a/backend/src/main/java/moim_today/implement/todo/TodoUpdater.java
+++ b/backend/src/main/java/moim_today/implement/todo/TodoUpdater.java
@@ -4,10 +4,12 @@ import moim_today.dto.todo.TodoUpdateRequest;
 import moim_today.dto.todo.TodoUpdateResponse;
 import moim_today.global.annotation.Implement;
 import moim_today.persistence.entity.todo.TodoJpaEntity;
+import org.springframework.transaction.annotation.Transactional;
 
 @Implement
 public class TodoUpdater {
 
+    @Transactional
     public TodoUpdateResponse updateTodo(final TodoJpaEntity originalTodo,
                                          final TodoUpdateRequest todoUpdateRequest) {
         originalTodo.updateTodo(todoUpdateRequest);

--- a/backend/src/main/java/moim_today/persistence/entity/todo/TodoJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/todo/TodoJpaEntity.java
@@ -49,4 +49,8 @@ public class TodoJpaEntity extends BaseTimeEntity {
         this.contents = todoUpdateRequest.contents();
         this.todoDate = todoUpdateRequest.todoDate();
     }
+
+    public void updateTodoProgress(final TodoProgress todoProgress) {
+        this.todoProgress = todoProgress;
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/todo/TodoRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/todo/TodoRepositoryImpl.java
@@ -52,19 +52,20 @@ public class TodoRepositoryImpl implements TodoRepository {
     @Override
     public List<TodoResponse> findAllByDateRange(final long memberId, final long moimId,
                                                  final LocalDate startDate, final LocalDate endDate) {
-                return queryFactory.select(
-                new QTodoResponse(
-                        todoJpaEntity.id,
-                        todoJpaEntity.contents,
-                        todoJpaEntity.todoProgress,
-                        todoJpaEntity.todoDate
-                ))
+        return queryFactory.select(
+                        new QTodoResponse(
+                                todoJpaEntity.id,
+                                todoJpaEntity.contents,
+                                todoJpaEntity.todoProgress,
+                                todoJpaEntity.todoDate
+                        ))
                 .from(todoJpaEntity)
                 .where(
                         todoJpaEntity.memberId.eq(memberId)
                                 .and(todoJpaEntity.moimId.eq(moimId))
                                 .and(todoJpaEntity.todoDate.between(startDate, endDate))
                 )
+                .orderBy(todoJpaEntity.moimId.asc())
                 .fetch();
     }
 

--- a/backend/src/main/java/moim_today/presentation/todo/TodoController.java
+++ b/backend/src/main/java/moim_today/presentation/todo/TodoController.java
@@ -30,9 +30,9 @@ public class TodoController {
     @GetMapping
     public CollectionResponse<List<MemberMoimTodoResponse>> findAllTodoByMemberId(
             @Login final MemberSession memberSession,
-            @RequestParam final YearMonth startDate,
+            @RequestParam final YearMonth requestDate,
             @RequestParam final int months){
-        return CollectionResponse.from(todoService.findAllMemberTodos(memberSession.id(), startDate, months));
+        return CollectionResponse.from(todoService.findAllMemberTodos(memberSession.id(), requestDate, months));
     }
 
     @GetMapping("moim/{moimId}")
@@ -54,6 +54,12 @@ public class TodoController {
     public TodoUpdateResponse updateTodo(@Login final MemberSession memberSession,
                                          @RequestBody final TodoUpdateRequest todoUpdateRequest) {
         return todoService.updateTodo(memberSession.id(), todoUpdateRequest);
+    }
+
+    @PatchMapping("/todo-progress")
+    public TodoUpdateResponse updateTodoProgress(@Login final MemberSession memberSession,
+                                                 @RequestBody final TodoProgressUpdateRequest todoProgressUpdateRequest){
+        return todoService.updateTodoProgress(memberSession.id(), todoProgressUpdateRequest);
     }
 
     @DeleteMapping

--- a/backend/src/main/java/moim_today/presentation/todo/TodoController.java
+++ b/backend/src/main/java/moim_today/presentation/todo/TodoController.java
@@ -32,17 +32,17 @@ public class TodoController {
             @Login final MemberSession memberSession,
             @RequestParam final YearMonth startDate,
             @RequestParam final int months){
-        return CollectionResponse.from(todoService.findAllMembersTodos(memberSession.id(), startDate, months));
+        return CollectionResponse.from(todoService.findAllMemberTodos(memberSession.id(), startDate, months));
     }
 
     @GetMapping("moim/{moimId}")
-    public CollectionResponse<List<MemberTodoResponse>> findAllMembersTodosInMoim(
+    public CollectionResponse<List<MemberTodoResponse>> findMembersTodosInMoim(
             @Login final MemberSession memberSession,
+            @RequestParam(required = false, defaultValue = "0") final long memberId,
             @PathVariable final long moimId,
-            @RequestParam final YearMonth startDate,
+            @RequestParam final YearMonth requestDate,
             @RequestParam final int months) {
-
-        return CollectionResponse.from(todoService.findAllMembersTodosInMoim(memberSession.id(), moimId, startDate, months));
+        return CollectionResponse.from(todoService.findMembersTodosInMoim(memberSession.id(), memberId, moimId, requestDate, months));
     }
 
     @GetMapping("/{todoId}")

--- a/backend/src/test/java/moim_today/domain/todo/TodoGroupByDateTest.java
+++ b/backend/src/test/java/moim_today/domain/todo/TodoGroupByDateTest.java
@@ -1,0 +1,60 @@
+package moim_today.domain.todo;
+
+import moim_today.dto.todo.TodoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static moim_today.domain.todo.enums.TodoProgress.PENDING;
+import static moim_today.util.TestConstant.TODO_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TodoGroupByDateTest {
+
+    @DisplayName("TodoResponse를 TodoGroupByDate로 변환할 수 있다")
+    @Test
+    void todoGroupByDates() {
+        final String contents = "투두 내용";
+        final LocalDate localDate = LocalDate.of(2024,5,25);
+
+        // given
+        TodoResponse todoResponse1 = TodoResponse.builder()
+                .todoId(TODO_ID.longValue())
+                .contents(contents)
+                .todoDate(localDate)
+                .todoProgress(PENDING)
+                .build();
+        TodoResponse todoResponse2 = TodoResponse.builder()
+                .todoId(TODO_ID.longValue() + 1L)
+                .contents(contents)
+                .todoDate(localDate)
+                .todoProgress(PENDING)
+                .build();
+        TodoResponse todoResponse3 = TodoResponse.builder()
+                .todoId(TODO_ID.longValue() + 2L)
+                .contents(contents)
+                .todoDate(localDate)
+                .todoProgress(PENDING)
+                .build();
+
+        List<TodoResponse> todoResponses = List.of(todoResponse1, todoResponse2, todoResponse3);
+
+        // when
+        List<TodoGroupByDate> todoGroupByDates = TodoGroupByDate.todoGroupByDates(todoResponses);
+
+        // then
+        assertThat(todoGroupByDates).hasSize(1);
+        assertThat(todoGroupByDates.get(0).todoDate()).isEqualTo(localDate);
+
+        List<TodoContents> todoContents = todoGroupByDates.get(0).todoContents();
+        assertThat(todoContents).hasSize(3);
+        assertThat(todoContents).extracting("todoId")
+                .containsExactlyInAnyOrder(todoResponse1.todoId(), todoResponse2.todoId(), todoResponse3.todoId());
+        assertThat(todoContents).extracting("contents")
+                .containsOnly(contents);
+        assertThat(todoContents).extracting("todoProgress")
+                .containsOnly(PENDING);
+    }
+}

--- a/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
+++ b/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
@@ -57,10 +57,9 @@ public class FakeTodoService implements TodoService {
                 .todoDate(LocalDate.of(2024, 5, 11))
                 .build();
 
-        MemberTodoResponse memberTodoResponse1 = MemberTodoResponse.builder()
-                .memberId(100L)
-                .todoResponses(Arrays.asList(todoResponse1, todoResponse2))
-                .build();
+        MemberTodoResponse memberTodoResponse1 = MemberTodoResponse.of(
+                100L,
+                Arrays.asList(todoResponse1, todoResponse2));
 
         TodoResponse todoResponse3 = TodoResponse.builder()
                 .todoId(3L)
@@ -76,10 +75,9 @@ public class FakeTodoService implements TodoService {
                 .todoDate(LocalDate.of(2024, 5, 13))
                 .build();
 
-        MemberTodoResponse memberTodoResponse2 = MemberTodoResponse.builder()
-                .memberId(101L)
-                .todoResponses(Arrays.asList(todoResponse3, todoResponse4))
-                .build();
+        MemberTodoResponse memberTodoResponse2 = MemberTodoResponse.of(
+                101L,
+                Arrays.asList(todoResponse3, todoResponse4));
 
         if (memberId == UNKNOWN_MEMBER.longValue()){
             return List.of(memberTodoResponse1, memberTodoResponse2);

--- a/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
+++ b/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static moim_today.domain.todo.enums.TodoProgress.COMPLETED;
 import static moim_today.domain.todo.enums.TodoProgress.PENDING;
+import static moim_today.global.constant.MemberConstant.UNKNOWN_MEMBER;
 import static moim_today.global.constant.exception.JoinedMoimExceptionConstant.JOINED_MOIM_MEMBER_NOT_FOUND;
 import static moim_today.global.constant.exception.TodoExceptionConstant.TODO_NOT_FOUND_ERROR;
 import static moim_today.global.constant.exception.TodoExceptionConstant.TODO_NOT_OWNER_ERROR;
@@ -36,11 +37,12 @@ public class FakeTodoService implements TodoService {
     }
 
     @Override
-    public List<MemberTodoResponse> findAllMembersTodosInMoim(final long memberId, final long moimId,
-                                                              final YearMonth startDate, final int months) {
+    public List<MemberTodoResponse> findMembersTodosInMoim(final long requestMemberId, final long memberId, final long moimId,
+                                                           final YearMonth startDate, final int months) {
         if (moimId == MOIM_ID.longValue() + 1L) {
             throw new NotFoundException(JOINED_MOIM_MEMBER_NOT_FOUND.message());
         }
+
         TodoResponse todoResponse1 = TodoResponse.builder()
                 .todoId(1L)
                 .contents("첫 번째 할 일")
@@ -79,7 +81,10 @@ public class FakeTodoService implements TodoService {
                 .todoResponses(Arrays.asList(todoResponse3, todoResponse4))
                 .build();
 
-        return List.of(memberTodoResponse1, memberTodoResponse2);
+        if (memberId == UNKNOWN_MEMBER.longValue()){
+            return List.of(memberTodoResponse1, memberTodoResponse2);
+        }
+        return List.of(memberTodoResponse1);
     }
 
     @Override
@@ -122,7 +127,7 @@ public class FakeTodoService implements TodoService {
     }
 
     @Override
-    public List<MemberMoimTodoResponse> findAllMembersTodos(final long memberId, final YearMonth startDate, final int months) {
+    public List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth startDate, final int months) {
         TodoResponse todo1 = TodoResponse.builder()
                 .todoId(TODO_ID.longValue())
                 .todoProgress(COMPLETED)
@@ -168,7 +173,7 @@ public class FakeTodoService implements TodoService {
     }
 
     @Override
-    public MemberMoimTodoResponse findMemberTodosInMoim(final long memberId, final Long moimId, final YearMonth startDate, final int months) {
+    public MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth startDate, final int months) {
         return null;
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
+++ b/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
@@ -38,7 +38,7 @@ public class FakeTodoService implements TodoService {
 
     @Override
     public List<MemberTodoResponse> findMembersTodosInMoim(final long requestMemberId, final long memberId, final long moimId,
-                                                           final YearMonth startDate, final int months) {
+                                                           final YearMonth requestDate, final int months) {
         if (moimId == MOIM_ID.longValue() + 1L) {
             throw new NotFoundException(JOINED_MOIM_MEMBER_NOT_FOUND.message());
         }
@@ -127,7 +127,7 @@ public class FakeTodoService implements TodoService {
     }
 
     @Override
-    public List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth startDate, final int months) {
+    public List<MemberMoimTodoResponse> findAllMemberTodos(final long memberId, final YearMonth requestDate, final int months) {
         TodoResponse todo1 = TodoResponse.builder()
                 .todoId(TODO_ID.longValue())
                 .todoProgress(COMPLETED)
@@ -173,7 +173,16 @@ public class FakeTodoService implements TodoService {
     }
 
     @Override
-    public MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth startDate, final int months) {
+    public MemberMoimTodoResponse findMemberMoimTodosInMoim(final long memberId, final long moimId, final YearMonth requestDate, final int months) {
         return null;
+    }
+
+    @Override
+    public TodoUpdateResponse updateTodoProgress(final long memberId, final TodoProgressUpdateRequest todoProgressUpdateRequest) {
+        return TodoUpdateResponse.from(TodoJpaEntity.builder()
+                .todoProgress(COMPLETED)
+                .contents("투두 완성하기")
+                .todoDate(LocalDate.of(2024, 5, 15))
+                .build());
     }
 }

--- a/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
+++ b/backend/src/test/java/moim_today/fake_class/todo/FakeTodoService.java
@@ -151,21 +151,9 @@ public class FakeTodoService implements TodoService {
                 .todoDate(LocalDate.of(2024, 5, 20))
                 .build();
 
-        MemberMoimTodoResponse m1 = MemberMoimTodoResponse.builder()
-                .moimId(MOIM_ID.longValue())
-                .moimTitle("U2DJ2 캡스톤 디자인")
-                .todoResponses(List.of(todo1, todo2))
-                .build();
-        MemberMoimTodoResponse m2 = MemberMoimTodoResponse.builder()
-                .moimId(MOIM_ID.longValue() + 2L)
-                .moimTitle("오늘의 운동 완료 모임")
-                .todoResponses(List.of(todo3))
-                .build();
-        MemberMoimTodoResponse m3 = MemberMoimTodoResponse.builder()
-                .moimId(MOIM_ID.longValue() + 5L)
-                .moimTitle("술이 문제야")
-                .todoResponses(List.of(todo4))
-                .build();
+        MemberMoimTodoResponse m1 = MemberMoimTodoResponse.of(MOIM_ID.longValue(), "U2DJ2 캡스톤 디자인", List.of(todo1, todo2));
+        MemberMoimTodoResponse m2 = MemberMoimTodoResponse.of(MOIM_ID.longValue() + 2L, "오늘의 운동 완료 모임", List.of(todo3));
+        MemberMoimTodoResponse m3 = MemberMoimTodoResponse.of(MOIM_ID.longValue() + 5L, "술이 문제야", List.of(todo4));
 
         return List.of(m1, m2, m3);
     }

--- a/backend/src/test/java/moim_today/implement/todo/TodoManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/todo/TodoManagerTest.java
@@ -256,4 +256,23 @@ class TodoManagerTest extends ImplementTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(TODO_NOT_FOUND_ERROR.message());
     }
+
+    @DisplayName("투두의 진행상황을 업데이트한다")
+    @Test
+    void updateTodoProgress() {
+        // given
+        TodoJpaEntity todoJpaEntity = TodoJpaEntity.builder()
+                .memberId(MEMBER_ID.longValue())
+                .todoProgress(PENDING)
+                .build();
+
+        todoRepository.save(todoJpaEntity);
+
+        // when
+        todoManager.updateTodoProgress(MEMBER_ID.longValue(), todoJpaEntity.getId(), COMPLETED);
+        TodoJpaEntity updatedTodo = todoRepository.getById(todoJpaEntity.getId());
+
+        // then
+        assertThat(updatedTodo.getTodoProgress()).isEqualTo(COMPLETED);
+    }
 }

--- a/backend/src/test/java/moim_today/implement/todo/TodoManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/todo/TodoManagerTest.java
@@ -1,5 +1,6 @@
 package moim_today.implement.todo;
 
+import moim_today.domain.todo.TodoGroupByDate;
 import moim_today.dto.todo.MemberTodoResponse;
 import moim_today.dto.todo.TodoRemoveRequest;
 import moim_today.dto.todo.TodoUpdateRequest;
@@ -92,7 +93,11 @@ class TodoManagerTest extends ImplementTest {
         // then
         assertThat(membersDataRangeTodosInMoim.size()).isEqualTo(MEMBER_SIZE);
         membersDataRangeTodosInMoim.forEach(m -> {
-            assertThat(m.todoResponses().size()).isEqualTo(EACH_MEMBER_TODO_SIZE_IN_MOIM);
+            int sum = 0;
+            for(TodoGroupByDate tg : m.todoGroupByDates()){
+                sum += tg.todoContents().size();
+            }
+            assertThat(sum).isEqualTo(EACH_MEMBER_TODO_SIZE_IN_MOIM);
         });
     }
 

--- a/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
@@ -226,12 +226,12 @@ public class TodoControllerTest extends ControllerTest {
                                 .responseFields(
                                         fieldWithPath("data[].moimId").type(NUMBER).description("자신이 만든 투두를 가지고 있는 모임 id"),
                                         fieldWithPath("data[].moimTitle").type(STRING).description("자신이 만든 투두를 가지고 있는 모임 title"),
-                                        fieldWithPath("data[].todoResponses[].todoId").type(NUMBER).description("투두 id"),
-                                        fieldWithPath("data[].todoResponses[].contents").type(STRING).description("투두 내용"),
-                                        fieldWithPath("data[].todoResponses[].todoProgress").type(VARIES).description(
+                                        fieldWithPath("data[].todoGroupByDates[].todoDate").type(NUMBER).description("투두 시작 시간"),
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].todoId").type(STRING).description("투두 id"),
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].todoProgress").type(VARIES).description(
                                                 String.format("투두 진행 상황 - %s", EnumDocsUtils.getEnumNames(TodoProgress.class))
                                         ),
-                                        fieldWithPath("data[].todoResponses[].todoDate").type(NUMBER).description("투두 시작 시간")
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].contents").type(NUMBER).description("투두 내용")
                                 )
                                 .build()
                         ))

--- a/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
@@ -143,7 +143,7 @@ public class TodoControllerTest extends ControllerTest {
                                 .queryParameters(
                                         parameterWithName("requestDate").description("조회를 시작할 월 - ex) 2024-05"),
                                         parameterWithName("months").description("조회를 시작할 월로부터 n개월 - ex) n=2 -> 2024-05-01 ~ 2024-07-31"),
-                                        parameterWithName("memberId").description("조회할 멤버 id")
+                                        parameterWithName("memberId").description("조회할 멤버 id , 0을 입력할 경우 모든 멤버의 투두 조회")
                                 )
                                 .responseFields(
                                         fieldWithPath("data[].memberId").type(NUMBER).description("투두 주인 id"),
@@ -184,7 +184,7 @@ public class TodoControllerTest extends ControllerTest {
                                 .queryParameters(
                                         parameterWithName("requestDate").description("조회를 시작할 월 - ex) 2024-05"),
                                         parameterWithName("months").description("조회를 시작할 월로부터 n개월 - ex) n=2 -> 2024-05-01 ~ 2024-07-31"),
-                                        parameterWithName("memberId").description("조회할 멤버 id")
+                                        parameterWithName("memberId").description("조회할 멤버 id , 0을 입력할 경우 모든 멤버의 투두 조회")
                                 )
                                 .responseFields(
                                         fieldWithPath("data[].memberId").type(NUMBER).description("투두 주인 id"),

--- a/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
@@ -148,12 +148,12 @@ public class TodoControllerTest extends ControllerTest {
                                 )
                                 .responseFields(
                                         fieldWithPath("data[].memberId").type(NUMBER).description("투두 주인 id"),
-                                        fieldWithPath("data[].todoResponses[].todoId").type(NUMBER).description("투두 id"),
-                                        fieldWithPath("data[].todoResponses[].contents").type(STRING).description("투두 내용"),
-                                        fieldWithPath("data[].todoResponses[].todoProgress").type(VARIES).description(
+                                        fieldWithPath("data[].todoGroupByDates[].todoDate").type(NUMBER).description("투두 시작 시간"),
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].todoId").type(STRING).description("투두 id"),
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].todoProgress").type(VARIES).description(
                                                 String.format("투두 진행 상황 - %s", EnumDocsUtils.getEnumNames(TodoProgress.class))
                                         ),
-                                        fieldWithPath("data[].todoResponses[].todoDate").type(NUMBER).description("투두 시작 시간")
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].contents").type(NUMBER).description("투두 내용")
                                 )
                                 .build()
                         ))
@@ -189,12 +189,12 @@ public class TodoControllerTest extends ControllerTest {
                                 )
                                 .responseFields(
                                         fieldWithPath("data[].memberId").type(NUMBER).description("투두 주인 id"),
-                                        fieldWithPath("data[].todoResponses[].todoId").type(NUMBER).description("투두 id"),
-                                        fieldWithPath("data[].todoResponses[].contents").type(STRING).description("투두 내용"),
-                                        fieldWithPath("data[].todoResponses[].todoProgress").type(VARIES).description(
+                                        fieldWithPath("data[].todoGroupByDates[].todoDate").type(NUMBER).description("투두 시작 시간"),
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].todoId").type(STRING).description("투두 id"),
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].todoProgress").type(VARIES).description(
                                                 String.format("투두 진행 상황 - %s", EnumDocsUtils.getEnumNames(TodoProgress.class))
                                         ),
-                                        fieldWithPath("data[].todoResponses[].todoDate").type(NUMBER).description("투두 시작 시간")
+                                        fieldWithPath("data[].todoGroupByDates[].todoContents[].contents").type(NUMBER).description("투두 내용")
                                 )
                                 .build()
                         ))

--- a/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
@@ -4,6 +4,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import moim_today.application.todo.TodoService;
 import moim_today.domain.todo.enums.TodoProgress;
 import moim_today.dto.todo.TodoCreateRequest;
+import moim_today.dto.todo.TodoProgressUpdateRequest;
 import moim_today.dto.todo.TodoRemoveRequest;
 import moim_today.dto.todo.TodoUpdateRequest;
 import moim_today.fake_class.todo.FakeTodoService;
@@ -126,7 +127,7 @@ public class TodoControllerTest extends ControllerTest {
         mockMvc.perform(
                         get("/api/todos/moim/{moimId}", MOIM_ID.longValue())
                                 .contentType(APPLICATION_JSON)
-                                .queryParam("memberId",MEMBER_ID)
+                                .queryParam("memberId", MEMBER_ID)
                                 .queryParam("requestDate", String.valueOf(
                                         YearMonth.of(2024, 5)
                                 ))
@@ -167,7 +168,7 @@ public class TodoControllerTest extends ControllerTest {
         mockMvc.perform(
                         get("/api/todos/moim/{moimId}", MOIM_ID.longValue())
                                 .contentType(APPLICATION_JSON)
-                                .queryParam("memberId","0")
+                                .queryParam("memberId", "0")
                                 .queryParam("requestDate", String.valueOf(
                                         YearMonth.of(2024, 5)
                                 ))
@@ -208,7 +209,7 @@ public class TodoControllerTest extends ControllerTest {
         mockMvc.perform(
                         get("/api/todos")
                                 .contentType(APPLICATION_JSON)
-                                .queryParam("startDate", String.valueOf(
+                                .queryParam("requestDate", String.valueOf(
                                         YearMonth.of(2024, 5)
                                 ))
                                 .queryParam("months", TWO_MONTHS)
@@ -219,7 +220,7 @@ public class TodoControllerTest extends ControllerTest {
                                 .tag("투두")
                                 .summary("자신의 모든 투두 조회")
                                 .queryParameters(
-                                        parameterWithName("startDate").description("조회를 시작할 월 - ex) 2024-05"),
+                                        parameterWithName("requestDate").description("조회를 시작할 월 - ex) 2024-05"),
                                         parameterWithName("months").description("조회를 시작할 월로부터 n개월 - ex) n=2 -> 2024-05-01 ~ 2024-07-31")
                                 )
                                 .responseFields(
@@ -245,7 +246,7 @@ public class TodoControllerTest extends ControllerTest {
         mockMvc.perform(
                         get("/api/todos/moim/{moimId}", MOIM_ID.longValue() + 1L)
                                 .contentType(APPLICATION_JSON)
-                                .queryParam("memberId","0")
+                                .queryParam("memberId", "0")
                                 .queryParam("requestDate", String.valueOf(
                                         YearMonth.of(2024, 5)
                                 ))
@@ -323,7 +324,7 @@ public class TodoControllerTest extends ControllerTest {
     @Test
     void updateTodoNotJoinedMemberError() throws Exception {
 
-        TodoUpdateRequest todoUpdateRequest = new TodoUpdateRequest(TODO_ID.longValue(), MOIM_ID.longValue()+1L,
+        TodoUpdateRequest todoUpdateRequest = new TodoUpdateRequest(TODO_ID.longValue(), MOIM_ID.longValue() + 1L,
                 UPDATE_AFTER_CONTENT.value(), COMPLETED, TODO_DATE);
 
         String json = objectMapper.writeValueAsString(todoUpdateRequest);
@@ -364,7 +365,7 @@ public class TodoControllerTest extends ControllerTest {
     @Test
     void updateTodoNotOwner() throws Exception {
 
-        TodoUpdateRequest todoUpdateRequest = new TodoUpdateRequest(TODO_ID.longValue(), MOIM_ID.longValue()+3L,
+        TodoUpdateRequest todoUpdateRequest = new TodoUpdateRequest(TODO_ID.longValue(), MOIM_ID.longValue() + 3L,
                 UPDATE_AFTER_CONTENT.value(), COMPLETED, TODO_DATE);
 
         String json = objectMapper.writeValueAsString(todoUpdateRequest);
@@ -403,7 +404,7 @@ public class TodoControllerTest extends ControllerTest {
 
     @DisplayName("Todo를 삭제한다")
     @Test
-    void deleteTodo() throws Exception{
+    void deleteTodo() throws Exception {
         TodoRemoveRequest todoRemoveRequest = new TodoRemoveRequest(TODO_ID.longValue());
 
         String json = objectMapper.writeValueAsString(todoRemoveRequest);
@@ -430,8 +431,8 @@ public class TodoControllerTest extends ControllerTest {
 
     @DisplayName("없는 투두 id면 Todo 삭제에 실패한다")
     @Test
-    void deleteTodoNotFoundError() throws Exception{
-        TodoRemoveRequest todoRemoveRequest = new TodoRemoveRequest(TODO_ID.longValue()+1L);
+    void deleteTodoNotFoundError() throws Exception {
+        TodoRemoveRequest todoRemoveRequest = new TodoRemoveRequest(TODO_ID.longValue() + 1L);
 
         String json = objectMapper.writeValueAsString(todoRemoveRequest);
 
@@ -461,8 +462,8 @@ public class TodoControllerTest extends ControllerTest {
 
     @DisplayName("투두의 주인이 아니면 Todo 삭제에 실패한다")
     @Test
-    void deleteTodoNotOwnerError() throws Exception{
-        TodoRemoveRequest todoRemoveRequest = new TodoRemoveRequest(TODO_ID.longValue()+2L);
+    void deleteTodoNotOwnerError() throws Exception {
+        TodoRemoveRequest todoRemoveRequest = new TodoRemoveRequest(TODO_ID.longValue() + 2L);
 
         String json = objectMapper.writeValueAsString(todoRemoveRequest);
 
@@ -492,8 +493,7 @@ public class TodoControllerTest extends ControllerTest {
 
     @DisplayName("하나의 Todo를 조회한다")
     @Test
-    void getTodoById() throws Exception{
-
+    void getTodoById() throws Exception {
 
         mockMvc.perform(get("/api/todos/{todoId}", TODO_ID.longValue())
                         .contentType(APPLICATION_JSON)
@@ -517,6 +517,47 @@ public class TodoControllerTest extends ControllerTest {
                                                         EnumDocsUtils.getEnumNames(TodoProgress.class))
                                         ),
                                         fieldWithPath("todoDate").type(NUMBER).description("투두 시작 시간")
+                                )
+                                .build()
+                        ))
+                );
+    }
+
+    @DisplayName("Todo의 todo progress를 업데이트한다")
+    @Test
+    void updateTodoProgress() throws Exception {
+        TodoProgressUpdateRequest todoProgressUpdateRequest = new TodoProgressUpdateRequest(
+                TODO_ID.longValue(), COMPLETED
+        );
+
+        String json = objectMapper.writeValueAsString(todoProgressUpdateRequest);
+
+        mockMvc.perform(patch("/api/todos/todo-progress")
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("투두 업데이트 성공",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("투두")
+                                .summary("투두 업데이트")
+                                .requestHeaders(
+                                        headerWithName("Content-Type").description("application/json")
+                                )
+                                .requestFields(
+                                        fieldWithPath("todoId").type(NUMBER).description("투두 id"),
+                                        fieldWithPath("todoProgress").type(VARIES).description(
+                                                String.format("투두 진행 상황 - %s", EnumDocsUtils.getEnumNames(TodoProgress.class))
+                                        )
+                                )
+                                .responseFields(
+                                        fieldWithPath("contents").type(STRING).description("업데이트 할 투두 컨텐츠 값"),
+                                        fieldWithPath("todoProgress").type(VARIES).description(
+                                                String.format("투두 진행 상황 - %s", EnumDocsUtils.getEnumNames(TodoProgress.class))
+                                        ),
+                                        fieldWithPath("todoDate").type(NUMBER).description("투두 시작 시간")
+                                                .attributes(key("format").value("yyyy-MM-dd"),
+                                                        key("timezone").value("Asia/Seoul"))
                                 )
                                 .build()
                         ))

--- a/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
+++ b/backend/src/test/java/moim_today/presentation/todo/TodoControllerTest.java
@@ -117,7 +117,49 @@ public class TodoControllerTest extends ControllerTest {
                 );
     }
 
-    @DisplayName("모임 안에 있는 모든 Todo를 조회한다")
+    @DisplayName("모임 안에 있는 모든 멤버의 Todo를 조회한다")
+    @Test
+    void findMembersTodosInMoim() throws Exception {
+        final String TWO_MONTHS = "2";
+        final String MEMBER_ID = "100";
+
+        mockMvc.perform(
+                        get("/api/todos/moim/{moimId}", MOIM_ID.longValue())
+                                .contentType(APPLICATION_JSON)
+                                .queryParam("memberId",MEMBER_ID)
+                                .queryParam("requestDate", String.valueOf(
+                                        YearMonth.of(2024, 5)
+                                ))
+                                .queryParam("months", TWO_MONTHS)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("모임 안에 특정 멤버의 모든 투두 조회",
+                        pathParameters(
+                                parameterWithName("moimId").description("모임 ID")
+                        ),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("투두")
+                                .summary("모임의 모든 투두 조회")
+                                .queryParameters(
+                                        parameterWithName("requestDate").description("조회를 시작할 월 - ex) 2024-05"),
+                                        parameterWithName("months").description("조회를 시작할 월로부터 n개월 - ex) n=2 -> 2024-05-01 ~ 2024-07-31"),
+                                        parameterWithName("memberId").description("조회할 멤버 id")
+                                )
+                                .responseFields(
+                                        fieldWithPath("data[].memberId").type(NUMBER).description("투두 주인 id"),
+                                        fieldWithPath("data[].todoResponses[].todoId").type(NUMBER).description("투두 id"),
+                                        fieldWithPath("data[].todoResponses[].contents").type(STRING).description("투두 내용"),
+                                        fieldWithPath("data[].todoResponses[].todoProgress").type(VARIES).description(
+                                                String.format("투두 진행 상황 - %s", EnumDocsUtils.getEnumNames(TodoProgress.class))
+                                        ),
+                                        fieldWithPath("data[].todoResponses[].todoDate").type(NUMBER).description("투두 시작 시간")
+                                )
+                                .build()
+                        ))
+                );
+    }
+
+    @DisplayName("memberId가 0일 경우 모임 안의 모든 멤버의 할일을 가져온다")
     @Test
     void findAllMembersTodosInMoim() throws Exception {
         final String TWO_MONTHS = "2";
@@ -125,7 +167,8 @@ public class TodoControllerTest extends ControllerTest {
         mockMvc.perform(
                         get("/api/todos/moim/{moimId}", MOIM_ID.longValue())
                                 .contentType(APPLICATION_JSON)
-                                .queryParam("startDate", String.valueOf(
+                                .queryParam("memberId","0")
+                                .queryParam("requestDate", String.valueOf(
                                         YearMonth.of(2024, 5)
                                 ))
                                 .queryParam("months", TWO_MONTHS)
@@ -139,11 +182,12 @@ public class TodoControllerTest extends ControllerTest {
                                 .tag("투두")
                                 .summary("모임의 모든 투두 조회")
                                 .queryParameters(
-                                        parameterWithName("startDate").description("조회를 시작할 월 - ex) 2024-05"),
-                                        parameterWithName("months").description("조회를 시작할 월로부터 n개월 - ex) n=2 -> 2024-05-01 ~ 2024-07-31")
+                                        parameterWithName("requestDate").description("조회를 시작할 월 - ex) 2024-05"),
+                                        parameterWithName("months").description("조회를 시작할 월로부터 n개월 - ex) n=2 -> 2024-05-01 ~ 2024-07-31"),
+                                        parameterWithName("memberId").description("조회할 멤버 id")
                                 )
                                 .responseFields(
-                                        fieldWithPath("data[].memberId").type(NUMBER).description("요청한 멤버 id"),
+                                        fieldWithPath("data[].memberId").type(NUMBER).description("투두 주인 id"),
                                         fieldWithPath("data[].todoResponses[].todoId").type(NUMBER).description("투두 id"),
                                         fieldWithPath("data[].todoResponses[].contents").type(STRING).description("투두 내용"),
                                         fieldWithPath("data[].todoResponses[].todoProgress").type(VARIES).description(
@@ -201,7 +245,8 @@ public class TodoControllerTest extends ControllerTest {
         mockMvc.perform(
                         get("/api/todos/moim/{moimId}", MOIM_ID.longValue() + 1L)
                                 .contentType(APPLICATION_JSON)
-                                .queryParam("startDate", String.valueOf(
+                                .queryParam("memberId","0")
+                                .queryParam("requestDate", String.valueOf(
                                         YearMonth.of(2024, 5)
                                 ))
                                 .queryParam("months", TWO_MONTHS)
@@ -215,8 +260,9 @@ public class TodoControllerTest extends ControllerTest {
                                 .tag("투두")
                                 .summary("모임의 모든 투두 조회")
                                 .queryParameters(
-                                        parameterWithName("startDate").description("조회를 시작할 월 - ex) 2024-05"),
-                                        parameterWithName("months").description("[조회를 시작할 월로부터 n개월] 을 지정하는 n")
+                                        parameterWithName("requestDate").description("조회를 시작할 월 - ex) 2024-05"),
+                                        parameterWithName("months").description("[조회를 시작할 월로부터 n개월] 을 지정하는 n"),
+                                        parameterWithName("memberId").description("조회할 멤버 id")
                                 )
                                 .responseFields(
                                         fieldWithPath("statusCode").type(STRING).description("상태 코드"),


### PR DESCRIPTION
## 📝작업 내용

> 프론트의 요구사항을 반영하여 투두를 투두 날짜로 그룹화하여 응답하도록 수정했고, 모임 pk 순으로 정렬하도록 수정했습니다.

## 💬리뷰 요구사항(선택)

> 데이터를 후처리하는 로직이 꽤 들어가기 때문에 도메인으로 분리하였습니다.
