### PR TITLE
[BE] 모임, 미팅 생성/참여시 회원의 캘린더 관리

### DIFF
--- a/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImpl.java
@@ -3,6 +3,11 @@ package moim_today.application.meeting.joined_meeting;
 import moim_today.implement.meeting.joined_meeting.JoinedMeetingFinder;
 import moim_today.implement.meeting.joined_meeting.JoinedMeetingRemover;
 import moim_today.implement.meeting.joined_meeting.JoinedMeetingUpdater;
+import moim_today.implement.meeting.meeting.MeetingFinder;
+import moim_today.implement.moim.moim.MoimFinder;
+import moim_today.implement.schedule.schedule.ScheduleAppender;
+import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,13 +18,22 @@ public class JoinedMeetingServiceImpl implements JoinedMeetingService {
     private final JoinedMeetingFinder joinedMeetingFinder;
     private final JoinedMeetingUpdater joinedMeetingUpdater;
     private final JoinedMeetingRemover joinedMeetingRemover;
+    private final MoimFinder moimFinder;
+    private final MeetingFinder meetingFinder;
+    private final ScheduleAppender scheduleAppender;
 
     public JoinedMeetingServiceImpl(final JoinedMeetingFinder joinedMeetingFinder,
                                     final JoinedMeetingUpdater joinedMeetingUpdater,
-                                    final JoinedMeetingRemover joinedMeetingRemover) {
+                                    final JoinedMeetingRemover joinedMeetingRemover,
+                                    final MoimFinder moimFinder,
+                                    final MeetingFinder meetingFinder,
+                                    final ScheduleAppender scheduleAppender) {
         this.joinedMeetingFinder = joinedMeetingFinder;
         this.joinedMeetingUpdater = joinedMeetingUpdater;
         this.joinedMeetingRemover = joinedMeetingRemover;
+        this.moimFinder = moimFinder;
+        this.meetingFinder = meetingFinder;
+        this.scheduleAppender = scheduleAppender;
     }
 
     @Override
@@ -32,6 +46,10 @@ public class JoinedMeetingServiceImpl implements JoinedMeetingService {
     public void acceptanceJoinMeeting(final long memberId, final long meetingId) {
         boolean attendance = true;
         joinedMeetingUpdater.updateAttendance(memberId, meetingId, attendance);
+        MeetingJpaEntity meetingJpaEntity = meetingFinder.getById(meetingId);
+        String moimTitle = moimFinder.getTitleById(meetingJpaEntity.getMoimId());
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.toEntity(memberId, moimTitle, meetingJpaEntity);
+        scheduleAppender.createScheduleIfNotExist(scheduleJpaEntity);
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImpl.java
@@ -6,6 +6,7 @@ import moim_today.implement.meeting.joined_meeting.JoinedMeetingUpdater;
 import moim_today.implement.meeting.meeting.MeetingFinder;
 import moim_today.implement.moim.moim.MoimFinder;
 import moim_today.implement.schedule.schedule.ScheduleAppender;
+import moim_today.implement.schedule.schedule.ScheduleRemover;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
 import org.springframework.stereotype.Service;
@@ -21,19 +22,22 @@ public class JoinedMeetingServiceImpl implements JoinedMeetingService {
     private final MoimFinder moimFinder;
     private final MeetingFinder meetingFinder;
     private final ScheduleAppender scheduleAppender;
+    private final ScheduleRemover scheduleRemover;
 
     public JoinedMeetingServiceImpl(final JoinedMeetingFinder joinedMeetingFinder,
                                     final JoinedMeetingUpdater joinedMeetingUpdater,
                                     final JoinedMeetingRemover joinedMeetingRemover,
                                     final MoimFinder moimFinder,
                                     final MeetingFinder meetingFinder,
-                                    final ScheduleAppender scheduleAppender) {
+                                    final ScheduleAppender scheduleAppender,
+                                    final ScheduleRemover scheduleRemover) {
         this.joinedMeetingFinder = joinedMeetingFinder;
         this.joinedMeetingUpdater = joinedMeetingUpdater;
         this.joinedMeetingRemover = joinedMeetingRemover;
         this.moimFinder = moimFinder;
         this.meetingFinder = meetingFinder;
         this.scheduleAppender = scheduleAppender;
+        this.scheduleRemover = scheduleRemover;
     }
 
     @Override
@@ -57,6 +61,7 @@ public class JoinedMeetingServiceImpl implements JoinedMeetingService {
     public void refuseJoinMeeting(final long memberId, final long meetingId) {
         boolean attendance = false;
         joinedMeetingUpdater.updateAttendance(memberId, meetingId, attendance);
+        scheduleRemover.deleteByMemberIdAndMeetingId(memberId, meetingId);
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppender.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppender.java
@@ -3,6 +3,7 @@ package moim_today.implement.meeting.joined_meeting;
 import moim_today.global.annotation.Implement;
 import moim_today.implement.moim.joined_moim.JoinedMoimFinder;
 import moim_today.implement.schedule.schedule.ScheduleAppender;
+import moim_today.implement.schedule.schedule.ScheduleFinder;
 import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
@@ -35,11 +36,14 @@ public class JoinedMeetingAppender {
             boolean alreadyJoinedMeeting = joinedMeetingRepository.alreadyJoinedMeeting(memberId, meetingId);
 
             if(!alreadyJoinedMeeting) {
-                JoinedMeetingJpaEntity joinedMeetingJpaEntity =
-                        JoinedMeetingJpaEntity.toEntity(meetingId, memberId, true);
-                joinedMeetingRepository.save(joinedMeetingJpaEntity);
                 ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.toEntity(memberId, moimTitle, meetingJpaEntity);
-                scheduleAppender.createScheduleIfNotExist(scheduleJpaEntity);
+                boolean isNew = scheduleAppender.createScheduleIfNotExist(scheduleJpaEntity);
+
+                if (isNew) {
+                    JoinedMeetingJpaEntity joinedMeetingJpaEntity =
+                            JoinedMeetingJpaEntity.toEntity(meetingId, memberId, true);
+                    joinedMeetingRepository.save(joinedMeetingJpaEntity);
+                }
             }
         }
     }

--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppender.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppender.java
@@ -2,11 +2,13 @@ package moim_today.implement.meeting.joined_meeting;
 
 import moim_today.global.annotation.Implement;
 import moim_today.implement.moim.joined_moim.JoinedMoimFinder;
+import moim_today.implement.schedule.schedule.ScheduleAppender;
 import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
+import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
 import moim_today.persistence.repository.meeting.joined_meeting.JoinedMeetingRepository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Implement
@@ -14,26 +16,31 @@ public class JoinedMeetingAppender {
 
     private final JoinedMeetingRepository joinedMeetingRepository;
     private final JoinedMoimFinder joinedMoimFinder;
+    private final ScheduleAppender scheduleAppender;
 
     public JoinedMeetingAppender(final JoinedMeetingRepository joinedMeetingRepository,
-                                 final JoinedMoimFinder joinedMoimFinder) {
+                                 final JoinedMoimFinder joinedMoimFinder,
+                                 final ScheduleAppender scheduleAppender) {
         this.joinedMeetingRepository = joinedMeetingRepository;
         this.joinedMoimFinder = joinedMoimFinder;
+        this.scheduleAppender = scheduleAppender;
     }
 
     @Transactional
-    public void saveJoinedMeeting(final long moimId, final long meetingId) {
+    public void saveJoinedMeeting(final long moimId, final long meetingId,
+                                  final String moimTitle, final MeetingJpaEntity meetingJpaEntity) {
         List<Long> memberIds = joinedMoimFinder.findAllJoinedMemberId(moimId);
-        List<JoinedMeetingJpaEntity> joinedMeetings = new ArrayList<>();
 
         for (long memberId : memberIds) {
             boolean alreadyJoinedMeeting = joinedMeetingRepository.alreadyJoinedMeeting(memberId, meetingId);
 
             if(!alreadyJoinedMeeting) {
-                JoinedMeetingJpaEntity joinedMeeting = JoinedMeetingJpaEntity.toEntity(meetingId, memberId, true);
-                joinedMeetings.add(joinedMeeting);
+                JoinedMeetingJpaEntity joinedMeetingJpaEntity =
+                        JoinedMeetingJpaEntity.toEntity(meetingId, memberId, true);
+                joinedMeetingRepository.save(joinedMeetingJpaEntity);
+                ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.toEntity(memberId, moimTitle, meetingJpaEntity);
+                scheduleAppender.createScheduleIfNotExist(scheduleJpaEntity);
             }
         }
-        joinedMeetingRepository.saveAll(joinedMeetings);
     }
 }

--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
@@ -23,7 +23,6 @@ public class JoinedMeetingUpdater {
         JoinedMeetingJpaEntity joinedMeetingJpaEntity =
                 joinedMeetingRepository.getByMemberIdAndMeetingId(memberId, meetingId);
         joinedMeetingJpaEntity.updateAttendance(attendance);
-
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
@@ -1,6 +1,7 @@
 package moim_today.implement.meeting.joined_meeting;
 
 import moim_today.global.annotation.Implement;
+import moim_today.implement.schedule.schedule.ScheduleAppender;
 import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
 import moim_today.persistence.repository.meeting.joined_meeting.JoinedMeetingRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,9 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class JoinedMeetingUpdater {
 
     private final JoinedMeetingRepository joinedMeetingRepository;
+    private final ScheduleAppender scheduleAppender;
 
-    public JoinedMeetingUpdater(final JoinedMeetingRepository joinedMeetingRepository) {
+    public JoinedMeetingUpdater(final JoinedMeetingRepository joinedMeetingRepository,
+                                final ScheduleAppender scheduleAppender) {
         this.joinedMeetingRepository = joinedMeetingRepository;
+        this.scheduleAppender = scheduleAppender;
     }
 
     @Transactional
@@ -19,6 +23,7 @@ public class JoinedMeetingUpdater {
         JoinedMeetingJpaEntity joinedMeetingJpaEntity =
                 joinedMeetingRepository.getByMemberIdAndMeetingId(memberId, meetingId);
         joinedMeetingJpaEntity.updateAttendance(attendance);
+
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingFinder.java
+++ b/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingFinder.java
@@ -60,4 +60,9 @@ public class MeetingFinder {
     public long getMoimIdByMeetingId(final long meetingId) {
         return meetingRepository.findMoimIdByMeetingId(meetingId);
     }
+
+    @Transactional(readOnly = true)
+    public MeetingJpaEntity getById(final long meetingId) {
+        return meetingRepository.getById(meetingId);
+    }
 }

--- a/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingFinder.java
+++ b/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingFinder.java
@@ -11,6 +11,7 @@ import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,6 +30,11 @@ public class MeetingFinder {
     @Transactional(readOnly = true)
     public List<Long> findMeetingIdsByMoimId(final long moimId) {
         return meetingRepository.findMeetingIdsByMoimId(moimId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findUpcomingMeetingIdsByMoimId(final long moimId, final LocalDate currentDate) {
+        return meetingRepository.findUpcomingMeetingIdsByMoimId(moimId, currentDate);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingManager.java
+++ b/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingManager.java
@@ -82,7 +82,8 @@ public class MeetingManager {
                 );
 
         MeetingJpaEntity saveEntity = meetingAppender.saveMeeting(meetingJpaEntity);
-        joinedMeetingAppender.saveJoinedMeeting(meetingCreateRequest.moimId(), meetingJpaEntity.getId());
+        moimFinder.getTitleById(meetingCreateRequest.moimId());
+        joinedMeetingAppender.saveJoinedMeeting(meetingCreateRequest.moimId(), meetingJpaEntity.getId(), moimTitle, saveEntity);
         createSchedules(moimTitle, meetingJpaEntity);
 
         return MeetingCreateResponse.of(saveEntity.getId(), meetingCreateRequest);
@@ -109,7 +110,8 @@ public class MeetingManager {
                 firstMeetingId = saveEntity.getId();
             }
 
-            joinedMeetingAppender.saveJoinedMeeting(meetingCreateRequest.moimId(), meetingJpaEntity.getId());
+            joinedMeetingAppender.saveJoinedMeeting(
+                    meetingCreateRequest.moimId(), meetingJpaEntity.getId(), moimTitle, meetingJpaEntity);
             createSchedules(moimTitle, meetingJpaEntity);
         }
 

--- a/backend/src/main/java/moim_today/implement/schedule/schedule/ScheduleAppender.java
+++ b/backend/src/main/java/moim_today/implement/schedule/schedule/ScheduleAppender.java
@@ -40,10 +40,13 @@ public class ScheduleAppender {
     }
 
     @Transactional
-    public void createScheduleIfNotExist(final ScheduleJpaEntity scheduleJpaEntity) {
+    public boolean createScheduleIfNotExist(final ScheduleJpaEntity scheduleJpaEntity) {
         if (!scheduleRepository.exists(scheduleJpaEntity)) {
             scheduleRepository.save(scheduleJpaEntity);
+            return true;
         }
+
+        return false;
     }
 
     private void validateAlreadyExist(final ScheduleJpaEntity scheduleJpaEntity) {

--- a/backend/src/main/java/moim_today/implement/schedule/schedule/ScheduleRemover.java
+++ b/backend/src/main/java/moim_today/implement/schedule/schedule/ScheduleRemover.java
@@ -41,4 +41,9 @@ public class ScheduleRemover {
             scheduleRepository.deleteAllByMemberInMeeting(memberId, meetingIds);
         }
     }
+
+    @Transactional
+    public void deleteByMemberIdAndMeetingId(final long memberId, final long meetingId) {
+        scheduleRepository.deleteByMemberIdAndMeetingId(memberId, meetingId);
+    }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepository.java
@@ -4,12 +4,15 @@ import moim_today.dto.mail.UpcomingMeetingNoticeResponse;
 import moim_today.dto.meeting.meeting.MeetingSimpleDao;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MeetingRepository {
 
     List<Long> findMeetingIdsByMoimId(final long moimId);
+
+    List<Long> findUpcomingMeetingIdsByMoimId(final long moimId, final LocalDate currentDate);
 
     List<MeetingSimpleDao> findAllByMoimId(final long moimId, final long memberId, final LocalDateTime currentDateTime);
 

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepositoryImpl.java
@@ -8,10 +8,12 @@ import moim_today.dto.meeting.meeting.QMeetingSimpleDao;
 import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.email_subscribe.QEmailSubscribeJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.meeting.meeting.QMeetingJpaEntity;
 import moim_today.persistence.entity.member.QMemberJpaEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -41,6 +43,16 @@ public class MeetingRepositoryImpl implements MeetingRepository {
                 .select(meetingJpaEntity.id)
                 .from(meetingJpaEntity)
                 .where(meetingJpaEntity.moimId.eq(moimId))
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findUpcomingMeetingIdsByMoimId(final long moimId, final LocalDate currentDate) {
+        return queryFactory
+                .select(meetingJpaEntity.id)
+                .from(meetingJpaEntity)
+                .where(meetingJpaEntity.moimId.eq(moimId)
+                        .and(meetingJpaEntity.startDateTime.goe(currentDate.atStartOfDay())))
                 .fetch();
     }
 

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/schedule/ScheduleJpaRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/schedule/ScheduleJpaRepository.java
@@ -11,5 +11,7 @@ public interface ScheduleJpaRepository extends JpaRepository<ScheduleJpaEntity, 
 
     void deleteAllByMeetingId(final long meetingId);
 
+    void deleteByMemberIdAndMeetingId(final long memberId, final long meetingId);
+
     List<ScheduleJpaEntity> findAllByMemberId(final long memberId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/schedule/ScheduleRepository.java
@@ -37,4 +37,6 @@ public interface ScheduleRepository {
     void deleteAllByMemberInMeeting(final long memberId, final List<Long> meetingIds);
 
     void deleteAllByMeetingId(final long meetingId);
+
+    void deleteByMemberIdAndMeetingId(final long memberId, final long meetingId);
 }

--- a/backend/src/main/java/moim_today/persistence/repository/schedule/schedule/ScheduleRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/schedule/schedule/ScheduleRepositoryImpl.java
@@ -186,4 +186,9 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
     public void deleteAllByMeetingId(final long meetingId) {
         scheduleJpaRepository.deleteAllByMeetingId(meetingId);
     }
+
+    @Override
+    public void deleteByMemberIdAndMeetingId(final long memberId, final long meetingId) {
+        scheduleJpaRepository.deleteByMemberIdAndMeetingId(memberId, meetingId);
+    }
 }

--- a/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
+++ b/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
@@ -1,0 +1,137 @@
+package moim_today.application.meeting.joined_meeting;
+
+import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
+import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.member.MemberJpaEntity;
+import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
+import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
+import moim_today.persistence.repository.meeting.joined_meeting.JoinedMeetingRepository;
+import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
+import moim_today.persistence.repository.member.MemberRepository;
+import moim_today.persistence.repository.moim.moim.MoimRepository;
+import moim_today.persistence.repository.schedule.schedule.ScheduleRepository;
+import moim_today.util.TestConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+class JoinedMeetingServiceImplTest {
+
+    @Autowired
+    private JoinedMeetingService joinedMeetingService;
+
+    @Autowired
+    private MoimRepository moimRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JoinedMeetingRepository joinedMeetingRepository;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @DisplayName("미팅에 참여하면 미팅 참여 여부가 참석으로 변경된다.")
+    @Test
+    void acceptanceJoinMeeting() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .title(TestConstant.MOIM_TITLE.value())
+                .startDate(LocalDate.of(2024, 3, 4))
+                .endDate(LocalDate.of(2024, 6, 30))
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 30, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 30, 12, 0, 0))
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 3
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 4
+        JoinedMeetingJpaEntity joinedMeetingJpaEntity = JoinedMeetingJpaEntity.builder()
+                .meetingId(meetingJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .attendance(false)
+                .build();
+
+        joinedMeetingRepository.save(joinedMeetingJpaEntity);
+
+        // when
+        joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+
+        // then
+        JoinedMeetingJpaEntity findEntity = joinedMeetingRepository.getById(joinedMeetingJpaEntity.getId());
+        assertThat(findEntity.isAttendance()).isTrue();
+    }
+
+    @DisplayName("미팅에 참여하면 스케줄 정보가 등록된다.")
+    @Test
+    void acceptanceJoinMeetingAndCreateSchedule() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .title(TestConstant.MOIM_TITLE.value())
+                .startDate(LocalDate.of(2024, 3, 4))
+                .endDate(LocalDate.of(2024, 6, 30))
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 30, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 30, 12, 0, 0))
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 3
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 4
+        JoinedMeetingJpaEntity joinedMeetingJpaEntity = JoinedMeetingJpaEntity.builder()
+                .meetingId(meetingJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .attendance(false)
+                .build();
+
+        joinedMeetingRepository.save(joinedMeetingJpaEntity);
+
+        // when
+        joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+
+        // then
+        List<ScheduleJpaEntity> scheduleJpaEntities = scheduleRepository.findAllByMemberId(memberJpaEntity.getId());
+        ScheduleJpaEntity scheduleJpaEntity = scheduleJpaEntities.get(0);
+        assertThat(scheduleJpaEntity.getStartDateTime()).isEqualTo(LocalDateTime.of(2024, 3, 30, 10, 0, 0));
+        assertThat(scheduleJpaEntity.getEndDateTime()).isEqualTo(LocalDateTime.of(2024, 3, 30, 12, 0, 0));
+        assertThat(scheduleJpaEntity.getScheduleName()).isEqualTo(moimJpaEntity.getTitle());
+    }
+}

--- a/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
+++ b/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
@@ -10,7 +10,9 @@ import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
 import moim_today.persistence.repository.member.MemberRepository;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
 import moim_today.persistence.repository.schedule.schedule.ScheduleRepository;
+import moim_today.util.DatabaseCleaner;
 import moim_today.util.TestConstant;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +45,14 @@ class JoinedMeetingServiceImplTest {
 
     @Autowired
     private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUpDatabase() {
+        databaseCleaner.cleanUp();
+    }
 
     @DisplayName("미팅에 참여하면 미팅 참여 여부가 참석으로 변경된다.")
     @Test
@@ -235,6 +245,6 @@ class JoinedMeetingServiceImplTest {
         joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
 
         // then
-        assertThat(scheduleRepository.count()).isEqualTo(1);
+        assertThat(scheduleRepository.count()).isEqualTo(0);
     }
 }

--- a/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
+++ b/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
@@ -134,4 +134,107 @@ class JoinedMeetingServiceImplTest {
         assertThat(scheduleJpaEntity.getEndDateTime()).isEqualTo(LocalDateTime.of(2024, 3, 30, 12, 0, 0));
         assertThat(scheduleJpaEntity.getScheduleName()).isEqualTo(moimJpaEntity.getTitle());
     }
+
+    @DisplayName("미팅 참석을 거절하면 미팅 참석 여부가 불참으로 변경된다.")
+    @Test
+    void refuseJoinMeeting() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .title(TestConstant.MOIM_TITLE.value())
+                .startDate(LocalDate.of(2024, 3, 4))
+                .endDate(LocalDate.of(2024, 6, 30))
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 30, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 30, 12, 0, 0))
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 3
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 4
+        JoinedMeetingJpaEntity joinedMeetingJpaEntity = JoinedMeetingJpaEntity.builder()
+                .meetingId(meetingJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .attendance(true)
+                .build();
+
+        joinedMeetingRepository.save(joinedMeetingJpaEntity);
+
+        // given 5
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .meetingId(meetingJpaEntity.getId())
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+
+        // then
+        JoinedMeetingJpaEntity findEntity = joinedMeetingRepository.getById(joinedMeetingJpaEntity.getId());
+        assertThat(findEntity.isAttendance()).isFalse();
+    }
+
+    @DisplayName("미팅 참석을 거절하면 해당 회원의 스케줄에서 삭제된다.")
+    @Test
+    void refuseJoinMeetingDeleteSchedule() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .title(TestConstant.MOIM_TITLE.value())
+                .startDate(LocalDate.of(2024, 3, 4))
+                .endDate(LocalDate.of(2024, 6, 30))
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 30, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 30, 12, 0, 0))
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 3
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 4
+        JoinedMeetingJpaEntity joinedMeetingJpaEntity = JoinedMeetingJpaEntity.builder()
+                .meetingId(meetingJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .attendance(true)
+                .build();
+
+        joinedMeetingRepository.save(joinedMeetingJpaEntity);
+
+        // given 5
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .meetingId(meetingJpaEntity.getId())
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+
+        // then
+        assertThat(scheduleRepository.count()).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppenderTest.java
@@ -191,4 +191,110 @@ class JoinedMeetingAppenderTest extends ImplementTest {
         // then
         assertThat(scheduleRepository.count()).isEqualTo(0);
     }
+
+    @DisplayName("모임 참여 정보를 바탕으로 미팅 참여 정보를 생성할 때 이미 해당 스케줄에 일정이 있으면 미팅에 참여하지 않는다.")
+    @Test
+    void saveJoinedMeetingAlreadyExistOtherSchedule() {
+        // given 1
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 2
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .title(MOIM_TITLE.value())
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 3
+        JoinedMoimJpaEntity joinedMoimJpaEntity = JoinedMoimJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .build();
+
+        joinedMoimRepository.save(joinedMoimJpaEntity);
+
+        // given 4
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 12, 0, 0))
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 5
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .meetingId(meetingJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 9, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 11, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        joinedMeetingAppender.saveJoinedMeeting(
+                moimJpaEntity.getId(), meetingJpaEntity.getId(), moimJpaEntity.getTitle(), meetingJpaEntity
+        );
+
+        // then
+        assertThat(scheduleRepository.count()).isEqualTo(1);
+        assertThat(joinedMeetingRepository.count()).isEqualTo(0);
+    }
+
+    @DisplayName("모임 참여 정보를 바탕으로 미팅 참여 정보를 생성할 때 다른 스케줄과 겹치지 않으면 미팅에 참여한다.")
+    @Test
+    void saveJoinedMeetingNotDuplicateOtherSchedule() {
+        // given 1
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.builder()
+                .build();
+
+        memberRepository.save(memberJpaEntity);
+
+        // given 2
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .title(MOIM_TITLE.value())
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 3
+        JoinedMoimJpaEntity joinedMoimJpaEntity = JoinedMoimJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .memberId(memberJpaEntity.getId())
+                .build();
+
+        joinedMoimRepository.save(joinedMoimJpaEntity);
+
+        // given 4
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 12, 0, 0))
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // given 5
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(memberJpaEntity.getId())
+                .meetingId(meetingJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 5, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 5, 12, 0, 0))
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        joinedMeetingAppender.saveJoinedMeeting(
+                moimJpaEntity.getId(), meetingJpaEntity.getId(), moimJpaEntity.getTitle(), meetingJpaEntity
+        );
+
+        // then
+        assertThat(scheduleRepository.count()).isEqualTo(2);
+        assertThat(joinedMeetingRepository.count()).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppenderTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static moim_today.util.TestConstant.*;
@@ -43,12 +44,16 @@ class JoinedMeetingAppenderTest extends ImplementTest {
         // given 3
         MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
                 .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 12, 0, 0))
                 .build();
 
         meetingRepository.save(meetingJpaEntity);
 
         // when
-        joinedMeetingAppender.saveJoinedMeeting(moimJpaEntity.getId(), meetingJpaEntity.getId());
+        joinedMeetingAppender.saveJoinedMeeting(
+                moimJpaEntity.getId(), meetingJpaEntity.getId(), moimJpaEntity.getTitle(), meetingJpaEntity
+        );
 
         // then
         assertThat(joinedMeetingRepository.count()).isEqualTo(10);
@@ -75,12 +80,16 @@ class JoinedMeetingAppenderTest extends ImplementTest {
         // given 3
         MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
                 .moimId(moimJpaEntity.getId())
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 12, 0, 0))
                 .build();
 
         meetingRepository.save(meetingJpaEntity);
 
         // when
-        joinedMeetingAppender.saveJoinedMeeting(moimJpaEntity.getId(), meetingJpaEntity.getId());
+        joinedMeetingAppender.saveJoinedMeeting(
+                moimJpaEntity.getId(), meetingJpaEntity.getId(), moimJpaEntity.getTitle(), meetingJpaEntity
+        );
 
         // then
         List<JoinedMeetingJpaEntity> findEntities = joinedMeetingRepository.findAll();

--- a/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
@@ -9,7 +9,6 @@ import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
 import moim_today.util.ImplementTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -289,7 +288,6 @@ class MeetingManagerTest extends ImplementTest {
 
         joinedMoimRepository.save(joinedMoimJpaEntity);
 
-
         ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
                 .memberId(memberId)
                 .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
@@ -313,7 +311,7 @@ class MeetingManagerTest extends ImplementTest {
 
         // then
         assertThat(meetingRepository.count()).isEqualTo(1);
-        assertThat(joinedMeetingRepository.count()).isEqualTo(1);
+        assertThat(joinedMeetingRepository.count()).isEqualTo(0);
         assertThat(scheduleRepository.count()).isEqualTo(1);
     }
 

--- a/backend/src/test/java/moim_today/implement/schedule/schedule/ScheduleRemoverTest.java
+++ b/backend/src/test/java/moim_today/implement/schedule/schedule/ScheduleRemoverTest.java
@@ -5,7 +5,6 @@ import moim_today.global.error.NotFoundException;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
 import moim_today.util.ImplementTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -222,5 +221,23 @@ class ScheduleRemoverTest extends ImplementTest {
                 .doesNotThrowAnyException();
         assertThatCode(() -> scheduleRepository.getById(savedSchedule2.getId()))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("회원 id와 미팅 id로 해당 스케줄을 삭제한다.")
+    @Test
+    void deleteByMemberIdAndMeetingId() {
+        // given
+        ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.builder()
+                .memberId(MEMBER_ID.longValue())
+                .meetingId(MEETING_ID.longValue())
+                .build();
+
+        scheduleRepository.save(scheduleJpaEntity);
+
+        // when
+        scheduleRemover.deleteByMemberIdAndMeetingId(MEMBER_ID.longValue(), MEETING_ID.longValue());
+
+        // then
+        assertThat(scheduleRepository.count()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 모임, 미팅 참여 여부에 따라 회원 각각의 캘린더에 등록이 되어야 합니다.
모임 주최자가 미팅을 생성하면 참여 인원의 캘린더에 모두 반영 
이미 있던 모임에 이후에 참여할 때 현재 시간을 기준으로 앞으로 다가오는 미팅 정보를 캘린더에 등록
미팅 참여/불참 선택 여부에 따라 캘린더에 바로 바로 반영이 되어야 합니다.

캘린더와 관련하여 다양한 엣지 케이스가 있는데 이러한 기능에 대한 테스트 코드도 추가하였습니다.

## 💬리뷰 요구사항(선택)

> 모임, 모임 참여 정보, 미팅, 미팅 참여 정보, 스케줄 등 많은 도메인, 엔티티가 엮여있습니다.
조금 복잡하지만 테스트 코드 위주로 봐주시면 될 것 같습니다.
