### PR TITLE
[BE] 어드민 미팅 조회/삭제

### DIFF
--- a/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
+++ b/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
@@ -17,7 +17,7 @@ public class AdminMeetingService {
     }
 
     @Transactional(readOnly = true)
-    public List<AdminMeetingResponse> findAll(final long moimId) {
+    public List<AdminMeetingResponse> findAllByMoimId(final long moimId) {
         return meetingRepository.findAllByAdminMoimId(moimId);
     }
 }

--- a/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
+++ b/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static moim_today.global.constant.exception.MeetingExceptionConstant.*;
+import static moim_today.global.constant.exception.MoimExceptionConstant.MOIM_FORBIDDEN_ERROR;
 
 @Service
 public class AdminMeetingService {
@@ -26,7 +27,11 @@ public class AdminMeetingService {
     }
 
     @Transactional(readOnly = true)
-    public List<AdminMeetingResponse> findAllByMoimId(final long moimId) {
+    public List<AdminMeetingResponse> findAllByMoimId(final long universityId, final long moimId) {
+        MoimJpaEntity moimJpaEntity = moimRepository.getById(moimId);
+        if (moimJpaEntity.getUniversityId() != universityId) {
+            throw new ForbiddenException(MOIM_FORBIDDEN_ERROR.message());
+        }
         return meetingRepository.findAllByAdminMoimId(moimId);
     }
 

--- a/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
+++ b/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
@@ -1,0 +1,23 @@
+package moim_today.application.admin.meeting;
+
+import moim_today.dto.admin.meeting.AdminMeetingResponse;
+import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class AdminMeetingService {
+
+    private final MeetingRepository meetingRepository;
+
+    public AdminMeetingService(final MeetingRepository meetingRepository) {
+        this.meetingRepository = meetingRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminMeetingResponse> findAll(final long moimId) {
+        return meetingRepository.findAllByAdminMoimId(moimId);
+    }
+}

--- a/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
+++ b/backend/src/main/java/moim_today/application/admin/meeting/AdminMeetingService.java
@@ -1,23 +1,44 @@
 package moim_today.application.admin.meeting;
 
 import moim_today.dto.admin.meeting.AdminMeetingResponse;
+import moim_today.global.error.ForbiddenException;
+import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
+import moim_today.persistence.repository.moim.moim.MoimRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static moim_today.global.constant.exception.MeetingExceptionConstant.*;
+
 @Service
 public class AdminMeetingService {
 
     private final MeetingRepository meetingRepository;
+    private final MoimRepository moimRepository;
 
-    public AdminMeetingService(final MeetingRepository meetingRepository) {
+    public AdminMeetingService(final MeetingRepository meetingRepository,
+                               final MoimRepository moimRepository) {
         this.meetingRepository = meetingRepository;
+        this.moimRepository = moimRepository;
     }
 
     @Transactional(readOnly = true)
     public List<AdminMeetingResponse> findAllByMoimId(final long moimId) {
         return meetingRepository.findAllByAdminMoimId(moimId);
+    }
+
+    @Transactional
+    public void deleteMeeting(final long universityId, final long meetingId) {
+        MeetingJpaEntity meetingJpaEntity = meetingRepository.getById(meetingId);
+        MoimJpaEntity moimJpaEntity = moimRepository.getById(meetingJpaEntity.getMoimId());
+
+        if (moimJpaEntity.getUniversityId() != universityId) {
+            throw new ForbiddenException(MEETING_FORBIDDEN_ERROR.message());
+        }
+
+        meetingRepository.delete(meetingJpaEntity);
     }
 }

--- a/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingService.java
+++ b/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingService.java
@@ -1,13 +1,15 @@
 package moim_today.application.meeting.joined_meeting;
 
 
+import java.time.LocalDateTime;
+
 public interface JoinedMeetingService {
 
     boolean findAttendanceStatus(final long memberId, final long meetingId);
 
-    void acceptanceJoinMeeting(final long memberId, final long meetingId);
+    void acceptanceJoinMeeting(final long memberId, final long meetingId, final LocalDateTime currentDateTime);
 
-    void refuseJoinMeeting(final long memberId, final long meetingId);
+    void refuseJoinMeeting(final long memberId, final long meetingId, final LocalDateTime currentDateTime);
 
     void deleteAllByMeetingId(final long meetingId);
 }

--- a/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImpl.java
+++ b/backend/src/main/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImpl.java
@@ -13,6 +13,8 @@ import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static moim_today.global.constant.exception.ScheduleExceptionConstant.*;
 
 
@@ -50,8 +52,9 @@ public class JoinedMeetingServiceImpl implements JoinedMeetingService {
 
     @Transactional
     @Override
-    public void acceptanceJoinMeeting(final long memberId, final long meetingId) {
+    public void acceptanceJoinMeeting(final long memberId, final long meetingId, final LocalDateTime currentDateTime) {
         MeetingJpaEntity meetingJpaEntity = meetingFinder.getById(meetingId);
+        meetingJpaEntity.validateCurrentTime(currentDateTime);
         String moimTitle = moimFinder.getTitleById(meetingJpaEntity.getMoimId());
         ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.toEntity(memberId, moimTitle, meetingJpaEntity);
         boolean isNew = scheduleAppender.createScheduleIfNotExist(scheduleJpaEntity);
@@ -66,7 +69,9 @@ public class JoinedMeetingServiceImpl implements JoinedMeetingService {
 
     @Transactional
     @Override
-    public void refuseJoinMeeting(final long memberId, final long meetingId) {
+    public void refuseJoinMeeting(final long memberId, final long meetingId, final LocalDateTime currentDateTime) {
+        MeetingJpaEntity meetingJpaEntity = meetingFinder.getById(meetingId);
+        meetingJpaEntity.validateCurrentTime(currentDateTime);
         boolean attendance = false;
         joinedMeetingUpdater.updateAttendance(memberId, meetingId, attendance);
         scheduleRemover.deleteByMemberIdAndMeetingId(memberId, meetingId);

--- a/backend/src/main/java/moim_today/dto/admin/meeting/AdminMeetingResponse.java
+++ b/backend/src/main/java/moim_today/dto/admin/meeting/AdminMeetingResponse.java
@@ -1,0 +1,23 @@
+package moim_today.dto.admin.meeting;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+
+public record AdminMeetingResponse(
+        long meetingId,
+        String agenda,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime startDateTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime endDateTime,
+
+        String place
+) {
+
+    @QueryProjection
+    public AdminMeetingResponse {
+    }
+}

--- a/backend/src/main/java/moim_today/global/config/SchedulingConfig.java
+++ b/backend/src/main/java/moim_today/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package moim_today.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {
+}

--- a/backend/src/main/java/moim_today/global/constant/exception/MeetingExceptionConstant.java
+++ b/backend/src/main/java/moim_today/global/constant/exception/MeetingExceptionConstant.java
@@ -6,6 +6,7 @@ public enum MeetingExceptionConstant {
     JOINED_MEETING_NOT_FOUND_ERROR("미팅 참석 정보가 존재하지 않습니다."),
     MEETING_COMMENT_FORBIDDEN_ERROR("댓글 작성자만 접근할 수 있습니다."),
     MEETING_DATE_TIME_BAD_REQUEST_ERROR("해당 시간대에 미팅을 생성할 수 없습니다."),
+    MEETING_PAST_TIME_BAD_REQUEST_ERROR("이미 지난 미팅입니다."),
     MEETING_FORBIDDEN_ERROR("해당 미팅에 대한 권한이 없습니다.");
 
     private final String message;

--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingUpdater.java
@@ -1,7 +1,6 @@
 package moim_today.implement.meeting.joined_meeting;
 
 import moim_today.global.annotation.Implement;
-import moim_today.implement.schedule.schedule.ScheduleAppender;
 import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
 import moim_today.persistence.repository.meeting.joined_meeting.JoinedMeetingRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,12 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class JoinedMeetingUpdater {
 
     private final JoinedMeetingRepository joinedMeetingRepository;
-    private final ScheduleAppender scheduleAppender;
 
-    public JoinedMeetingUpdater(final JoinedMeetingRepository joinedMeetingRepository,
-                                final ScheduleAppender scheduleAppender) {
+    public JoinedMeetingUpdater(final JoinedMeetingRepository joinedMeetingRepository) {
         this.joinedMeetingRepository = joinedMeetingRepository;
-        this.scheduleAppender = scheduleAppender;
     }
 
     @Transactional

--- a/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingFinder.java
+++ b/backend/src/main/java/moim_today/implement/meeting/meeting/MeetingFinder.java
@@ -6,6 +6,7 @@ import moim_today.dto.meeting.meeting.MeetingDetailResponse;
 import moim_today.dto.meeting.meeting.MeetingSimpleDao;
 import moim_today.dto.member.MemberSimpleResponse;
 import moim_today.global.annotation.Implement;
+import moim_today.global.error.BadRequestException;
 import moim_today.implement.meeting.joined_meeting.JoinedMeetingFinder;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static moim_today.global.constant.exception.MeetingExceptionConstant.*;
 
 @Implement
 public class MeetingFinder {

--- a/backend/src/main/java/moim_today/persistence/entity/meeting/meeting/MeetingJpaEntity.java
+++ b/backend/src/main/java/moim_today/persistence/entity/meeting/meeting/MeetingJpaEntity.java
@@ -5,8 +5,11 @@ import moim_today.global.base_entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import moim_today.global.error.BadRequestException;
 
 import java.time.LocalDateTime;
+
+import static moim_today.global.constant.exception.MeetingExceptionConstant.MEETING_PAST_TIME_BAD_REQUEST_ERROR;
 
 @Getter
 @Table(name = "meeting")
@@ -44,5 +47,11 @@ public class MeetingJpaEntity extends BaseTimeEntity {
     public void updateMeeting(final String agenda, final String place) {
         this.agenda = agenda;
         this.place = place;
+    }
+
+    public void validateCurrentTime(final LocalDateTime currentDateTime) {
+        if (startDateTime.isBefore(currentDateTime)) {
+            throw new BadRequestException(MEETING_PAST_TIME_BAD_REQUEST_ERROR.message());
+        }
     }
 }

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/joined_meeting/JoinedMeetingRepositoryImpl.java
@@ -94,7 +94,9 @@ public class JoinedMeetingRepositoryImpl implements JoinedMeetingRepository {
                 )
                 .from(joinedMeetingJpaEntity)
                 .join(memberJpaEntity).on(memberJpaEntity.id.eq(joinedMeetingJpaEntity.memberId))
-                .where(joinedMeetingJpaEntity.meetingId.eq(meetingId))
+                .where(joinedMeetingJpaEntity.meetingId.eq(meetingId)
+                        .and(joinedMeetingJpaEntity.attendance.isTrue())
+                )
                 .fetch();
     }
 

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepository.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepository.java
@@ -1,5 +1,6 @@
 package moim_today.persistence.repository.meeting.meeting;
 
+import moim_today.dto.admin.meeting.AdminMeetingResponse;
 import moim_today.dto.mail.UpcomingMeetingNoticeResponse;
 import moim_today.dto.meeting.meeting.MeetingSimpleDao;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
@@ -19,6 +20,8 @@ public interface MeetingRepository {
     List<MeetingSimpleDao> findAllUpcomingByMoimId(final long moimId, final long memberId, final LocalDateTime currentDateTime);
 
     List<MeetingSimpleDao> findAllPastByMoimId(final long moimId, final long memberId, final LocalDateTime currentDateTime);
+
+    List<AdminMeetingResponse> findAllByAdminMoimId(final long moimId);
 
     long getHostIdByMeetingId(final long meetingId);
 

--- a/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/meeting/meeting/MeetingRepositoryImpl.java
@@ -1,6 +1,8 @@
 package moim_today.persistence.repository.meeting.meeting;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import moim_today.dto.admin.meeting.AdminMeetingResponse;
+import moim_today.dto.admin.meeting.QAdminMeetingResponse;
 import moim_today.dto.mail.QUpcomingMeetingNoticeResponse;
 import moim_today.dto.mail.UpcomingMeetingNoticeResponse;
 import moim_today.dto.meeting.meeting.MeetingSimpleDao;
@@ -10,6 +12,7 @@ import moim_today.persistence.entity.email_subscribe.QEmailSubscribeJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.QMeetingJpaEntity;
 import moim_today.persistence.entity.member.QMemberJpaEntity;
+import moim_today.persistence.entity.moim.moim.QMoimJpaEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -115,6 +118,21 @@ public class MeetingRepositoryImpl implements MeetingRepository {
                         .and(joinedMeetingJpaEntity.memberId.eq(memberId))
                 )
                 .orderBy(meetingJpaEntity.startDateTime.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<AdminMeetingResponse> findAllByAdminMoimId(final long moimId) {
+        return queryFactory.select(
+                        new QAdminMeetingResponse(
+                                meetingJpaEntity.id,
+                                meetingJpaEntity.agenda,
+                                meetingJpaEntity.startDateTime,
+                                meetingJpaEntity.endDateTime,
+                                meetingJpaEntity.place
+                        ))
+                .from(meetingJpaEntity)
+                .where(meetingJpaEntity.moimId.eq(moimId))
                 .fetch();
     }
 

--- a/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
+++ b/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
@@ -16,9 +16,10 @@ public class AdminMeetingController {
         this.adminMeetingService = adminMeetingService;
     }
 
+    // todo AdminSession 적용
     @GetMapping("/meetings/{moimId}")
-    public List<AdminMeetingResponse> findAllByMoimId(@PathVariable final long moimId) {
-        return adminMeetingService.findAllByMoimId(moimId);
+    public List<AdminMeetingResponse> findAllByMoimId(final long universityId, @PathVariable final long moimId) {
+        return adminMeetingService.findAllByMoimId(universityId, moimId);
     }
 
     // todo AdminSession 적용

--- a/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
+++ b/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
@@ -2,10 +2,7 @@ package moim_today.presentation.admin.meeting;
 
 import moim_today.application.admin.meeting.AdminMeetingService;
 import moim_today.dto.admin.meeting.AdminMeetingResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,5 +19,11 @@ public class AdminMeetingController {
     @GetMapping("/meetings/{moimId}")
     public List<AdminMeetingResponse> findAllByMoimId(@PathVariable final long moimId) {
         return adminMeetingService.findAllByMoimId(moimId);
+    }
+
+    // todo AdminSession 적용
+    @DeleteMapping("/meetings/{meetingId}")
+    public void deleteMeeting(final long universityId, @PathVariable final long meetingId) {
+        adminMeetingService.deleteMeeting(universityId, meetingId);
     }
 }

--- a/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
+++ b/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
@@ -1,0 +1,26 @@
+package moim_today.presentation.admin.meeting;
+
+import moim_today.application.admin.meeting.AdminMeetingService;
+import moim_today.dto.admin.meeting.AdminMeetingResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/admin")
+@RestController
+public class AdminMeetingController {
+
+    private final AdminMeetingService adminMeetingService;
+
+    public AdminMeetingController(final AdminMeetingService adminMeetingService) {
+        this.adminMeetingService = adminMeetingService;
+    }
+
+    @GetMapping("/meetings/{moimId}")
+    public List<AdminMeetingResponse> findAllByUniversityId(@PathVariable final long moimId) {
+        return adminMeetingService.findAll(moimId);
+    }
+}

--- a/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
+++ b/backend/src/main/java/moim_today/presentation/admin/meeting/AdminMeetingController.java
@@ -20,7 +20,7 @@ public class AdminMeetingController {
     }
 
     @GetMapping("/meetings/{moimId}")
-    public List<AdminMeetingResponse> findAllByUniversityId(@PathVariable final long moimId) {
-        return adminMeetingService.findAll(moimId);
+    public List<AdminMeetingResponse> findAllByMoimId(@PathVariable final long moimId) {
+        return adminMeetingService.findAllByMoimId(moimId);
     }
 }

--- a/backend/src/main/java/moim_today/presentation/meeting/joined_meeting/JoinedMeetingController.java
+++ b/backend/src/main/java/moim_today/presentation/meeting/joined_meeting/JoinedMeetingController.java
@@ -6,6 +6,8 @@ import moim_today.dto.meeting.meeting.MeetingAttendanceResponse;
 import moim_today.global.annotation.Login;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RequestMapping("/api")
 @RestController
 public class JoinedMeetingController {
@@ -26,12 +28,12 @@ public class JoinedMeetingController {
     @PostMapping("/members/meetings/{meetingId}/acceptance")
     public void acceptanceJoinMeeting(@Login final MemberSession memberSession,
                                       @PathVariable final long meetingId) {
-        joinedMeetingService.acceptanceJoinMeeting(memberSession.id(), meetingId);
+        joinedMeetingService.acceptanceJoinMeeting(memberSession.id(), meetingId, LocalDateTime.now());
     }
 
     @PostMapping("/members/meetings/{meetingId}/refusal")
     public void refuseJoinMeeting(@Login final MemberSession memberSession,
                                   @PathVariable final long meetingId) {
-        joinedMeetingService.refuseJoinMeeting(memberSession.id(), meetingId);
+        joinedMeetingService.refuseJoinMeeting(memberSession.id(), meetingId, LocalDateTime.now());
     }
 }

--- a/backend/src/test/java/moim_today/application/admin/meeting/AdminMeetingServiceTest.java
+++ b/backend/src/test/java/moim_today/application/admin/meeting/AdminMeetingServiceTest.java
@@ -7,6 +7,8 @@ import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
 import moim_today.util.DatabaseCleaner;
+import moim_today.util.TestConstant;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 import static moim_today.global.constant.exception.MeetingExceptionConstant.MEETING_FORBIDDEN_ERROR;
+import static moim_today.global.constant.exception.MoimExceptionConstant.MOIM_FORBIDDEN_ERROR;
 import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -45,6 +48,7 @@ class AdminMeetingServiceTest {
     void findAllByMoimId() {
         // given 1
         MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .universityId(UNIV_ID.longValue())
                 .build();
 
         moimRepository.save(moimJpaEntity);
@@ -67,10 +71,44 @@ class AdminMeetingServiceTest {
         meetingRepository.save(otherMeetingJpaEntity);
 
         // when
-        List<AdminMeetingResponse> adminMeetingResponses = adminMeetingService.findAllByMoimId(moimJpaEntity.getId());
+        List<AdminMeetingResponse> adminMeetingResponses =
+                adminMeetingService.findAllByMoimId(UNIV_ID.longValue(), moimJpaEntity.getId());
 
         // then
         assertThat(adminMeetingResponses.size()).isEqualTo(2);
+    }
+
+    @DisplayName("모임 id에 맞는 미팅 정보를 찾는다.")
+    @Test
+    void findAllByMoimIdForbidden() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .universityId(UNIV_ID.longValue() + 1)
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity1 = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .build();
+
+        MeetingJpaEntity meetingJpaEntity2 = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .build();
+
+        MeetingJpaEntity otherMeetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId() + 1)
+                .build();
+
+        meetingRepository.save(meetingJpaEntity1);
+        meetingRepository.save(meetingJpaEntity2);
+        meetingRepository.save(otherMeetingJpaEntity);
+
+        // when
+        assertThatThrownBy(() -> adminMeetingService.findAllByMoimId(UNIV_ID.longValue(), moimJpaEntity.getId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(MOIM_FORBIDDEN_ERROR.message());
     }
 
     @DisplayName("어드민 권한으로 미팅을 삭제한다.")

--- a/backend/src/test/java/moim_today/application/admin/meeting/AdminMeetingServiceTest.java
+++ b/backend/src/test/java/moim_today/application/admin/meeting/AdminMeetingServiceTest.java
@@ -1,0 +1,62 @@
+package moim_today.application.admin.meeting;
+
+import moim_today.dto.admin.meeting.AdminMeetingResponse;
+import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
+import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
+import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
+import moim_today.persistence.repository.moim.moim.MoimRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+class AdminMeetingServiceTest {
+
+    @Autowired
+    private AdminMeetingService adminMeetingService;
+
+    @Autowired
+    private MoimRepository moimRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @DisplayName("모임 id에 맞는 미팅 정보를 찾는다.")
+    @Test
+    void findAllByMoimId() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity1 = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .build();
+
+        MeetingJpaEntity meetingJpaEntity2 = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .build();
+
+        MeetingJpaEntity otherMeetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId() + 1)
+                .build();
+
+        meetingRepository.save(meetingJpaEntity1);
+        meetingRepository.save(meetingJpaEntity2);
+        meetingRepository.save(otherMeetingJpaEntity);
+
+        // when
+        List<AdminMeetingResponse> adminMeetingResponses = adminMeetingService.findAllByMoimId(moimJpaEntity.getId());
+
+        // then
+        assertThat(adminMeetingResponses.size()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/moim_today/application/admin/meeting/AdminMeetingServiceTest.java
+++ b/backend/src/test/java/moim_today/application/admin/meeting/AdminMeetingServiceTest.java
@@ -1,10 +1,13 @@
 package moim_today.application.admin.meeting;
 
 import moim_today.dto.admin.meeting.AdminMeetingResponse;
+import moim_today.global.error.ForbiddenException;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.persistence.repository.meeting.meeting.MeetingRepository;
 import moim_today.persistence.repository.moim.moim.MoimRepository;
+import moim_today.util.DatabaseCleaner;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +15,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static moim_today.global.constant.exception.MeetingExceptionConstant.MEETING_FORBIDDEN_ERROR;
+import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 
@@ -26,6 +31,14 @@ class AdminMeetingServiceTest {
 
     @Autowired
     private MeetingRepository meetingRepository;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUpDatabase() {
+        databaseCleaner.cleanUp();
+    }
 
     @DisplayName("모임 id에 맞는 미팅 정보를 찾는다.")
     @Test
@@ -58,5 +71,55 @@ class AdminMeetingServiceTest {
 
         // then
         assertThat(adminMeetingResponses.size()).isEqualTo(2);
+    }
+
+    @DisplayName("어드민 권한으로 미팅을 삭제한다.")
+    @Test
+    void deleteMeeting() {
+        // given 1
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .universityId(UNIV_ID.longValue())
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // when
+        adminMeetingService.deleteMeeting(UNIV_ID.longValue(), meetingJpaEntity.getId());
+
+        // then
+        assertThat(meetingRepository.count()).isEqualTo(0);
+    }
+
+    @DisplayName("해당 학교의 관리자가 아니면 미팅을 삭제할 수 없다.")
+    @Test
+    void deleteMeetingForbidden() {
+        // given 1
+        long universityId = UNIV_ID.longValue();
+        long otherUniversityId = UNIV_ID.longValue() + 1;
+
+        MoimJpaEntity moimJpaEntity = MoimJpaEntity.builder()
+                .universityId(universityId)
+                .build();
+
+        moimRepository.save(moimJpaEntity);
+
+        // given 2
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .moimId(moimJpaEntity.getId())
+                .build();
+
+        meetingRepository.save(meetingJpaEntity);
+
+        // expected
+        assertThatThrownBy(() -> adminMeetingService.deleteMeeting(otherUniversityId, meetingJpaEntity.getId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(MEETING_FORBIDDEN_ERROR.message());
     }
 }

--- a/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
+++ b/backend/src/test/java/moim_today/application/meeting/joined_meeting/JoinedMeetingServiceImplTest.java
@@ -93,8 +93,11 @@ class JoinedMeetingServiceImplTest {
 
         joinedMeetingRepository.save(joinedMeetingJpaEntity);
 
+        // given 5
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+
         // when
-        joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+        joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId(), currentDateTime);
 
         // then
         JoinedMeetingJpaEntity findEntity = joinedMeetingRepository.getById(joinedMeetingJpaEntity.getId());
@@ -137,8 +140,11 @@ class JoinedMeetingServiceImplTest {
 
         joinedMeetingRepository.save(joinedMeetingJpaEntity);
 
+        // given 5
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+
         // when
-        joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+        joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId(), currentDateTime);
 
         // then
         List<ScheduleJpaEntity> scheduleJpaEntities = scheduleRepository.findAllByMemberId(memberJpaEntity.getId());
@@ -195,8 +201,11 @@ class JoinedMeetingServiceImplTest {
 
         joinedMeetingRepository.save(joinedMeetingJpaEntity);
 
+        // given 6
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+
         // expected
-        assertThatThrownBy(() -> joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId()))
+        assertThatThrownBy(() -> joinedMeetingService.acceptanceJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId(), currentDateTime))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(SCHEDULE_ALREADY_EXIST.message());
 
@@ -249,8 +258,11 @@ class JoinedMeetingServiceImplTest {
 
         scheduleRepository.save(scheduleJpaEntity);
 
+        // given 6
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+
         // when
-        joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+        joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId(), currentDateTime);
 
         // then
         JoinedMeetingJpaEntity findEntity = joinedMeetingRepository.getById(joinedMeetingJpaEntity.getId());
@@ -301,8 +313,11 @@ class JoinedMeetingServiceImplTest {
 
         scheduleRepository.save(scheduleJpaEntity);
 
+        // given 6
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+
         // when
-        joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId());
+        joinedMeetingService.refuseJoinMeeting(memberJpaEntity.getId(), meetingJpaEntity.getId(), currentDateTime);
 
         // then
         assertThat(scheduleRepository.count()).isEqualTo(0);

--- a/backend/src/test/java/moim_today/fake_class/meeting/joined_meeting/FakeJoinedMeetingService.java
+++ b/backend/src/test/java/moim_today/fake_class/meeting/joined_meeting/FakeJoinedMeetingService.java
@@ -2,6 +2,8 @@ package moim_today.fake_class.meeting.joined_meeting;
 
 import moim_today.application.meeting.joined_meeting.JoinedMeetingService;
 
+import java.time.LocalDateTime;
+
 public class FakeJoinedMeetingService implements JoinedMeetingService {
 
     @Override
@@ -10,12 +12,12 @@ public class FakeJoinedMeetingService implements JoinedMeetingService {
     }
 
     @Override
-    public void acceptanceJoinMeeting(final long memberId, final long meetingId) {
+    public void acceptanceJoinMeeting(final long memberId, final long meetingId, final LocalDateTime currentDateTime) {
 
     }
 
     @Override
-    public void refuseJoinMeeting(final long memberId, final long meetingId) {
+    public void refuseJoinMeeting(final long memberId, final long meetingId, final LocalDateTime currentDateTime) {
 
     }
 

--- a/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingFinderTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingFinderTest.java
@@ -401,11 +401,13 @@ class MeetingFinderTest extends ImplementTest {
         JoinedMeetingJpaEntity joinedMeetingJpaEntity1 = JoinedMeetingJpaEntity.builder()
                 .meetingId(meetingJpaEntity.getId())
                 .memberId(memberJpaEntity1.getId())
+                .attendance(true)
                 .build();
 
         JoinedMeetingJpaEntity joinedMeetingJpaEntity2 = JoinedMeetingJpaEntity.builder()
                 .meetingId(meetingJpaEntity.getId())
                 .memberId(memberJpaEntity2.getId())
+                .attendance(false)
                 .build();
 
         joinedMeetingRepository.save(joinedMeetingJpaEntity1);
@@ -420,7 +422,7 @@ class MeetingFinderTest extends ImplementTest {
         assertThat(meetingDetailResponse.startDateTime()).isEqualTo(LocalDateTime.of(2024, 3, 4, 10, 0, 0));
         assertThat(meetingDetailResponse.endDateTime()).isEqualTo(LocalDateTime.of(2024, 3, 4, 12, 0, 0));
         assertThat(meetingDetailResponse.place()).isEqualTo(MEETING_PLACE.value());
-        assertThat(meetingDetailResponse.members().size()).isEqualTo(2);
+        assertThat(meetingDetailResponse.members().size()).isEqualTo(1);
     }
 
     @DisplayName("다가오는 미팅 정보들을 조회한다.")

--- a/backend/src/test/java/moim_today/persistence/entity/meeting/meeting/MeetingJpaEntityTest.java
+++ b/backend/src/test/java/moim_today/persistence/entity/meeting/meeting/MeetingJpaEntityTest.java
@@ -1,10 +1,15 @@
 package moim_today.persistence.entity.meeting.meeting;
 
+import moim_today.global.error.BadRequestException;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
 import moim_today.util.TestConstant;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
+import static moim_today.global.constant.exception.MeetingExceptionConstant.MEETING_PAST_TIME_BAD_REQUEST_ERROR;
 import static moim_today.util.TestConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -29,5 +34,38 @@ class MeetingJpaEntityTest {
         // then
         assertThat(meetingJpaEntity.getAgenda()).isEqualTo(newAgenda);
         assertThat(meetingJpaEntity.getPlace()).isEqualTo(newPlace);
+    }
+
+    @DisplayName("현재 시간이 미팅 시작 시간보다 앞에 있으면 검증에 성공한다.")
+    @Test
+    void validateCurrentTime() {
+        // given
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .build();
+
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 4, 9, 59, 59);
+
+        // when
+        assertThatCode(() -> meetingJpaEntity.validateCurrentTime(currentDateTime))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("현재 시간이 미팅 시작 시간보다 뒤에 있으면 예외가 발생한다.")
+    @Test
+    void validateCurrentTimeFail() {
+        // given
+        MeetingJpaEntity meetingJpaEntity = MeetingJpaEntity.builder()
+                .startDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .endDateTime(LocalDateTime.of(2024, 3, 4, 10, 0, 0))
+                .build();
+
+        LocalDateTime currentDateTime = LocalDateTime.of(2024, 3, 4, 10, 0, 1);
+
+        // when
+        assertThatThrownBy(() -> meetingJpaEntity.validateCurrentTime(currentDateTime))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MEETING_PAST_TIME_BAD_REQUEST_ERROR.message());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #221 

## 📝작업 내용

> 스케줄링 설정 추가
 어드민 미팅 조회 기능
 어드민 미팅 삭제 기능
 미팅 참여에 따른 캘린더 관리
 미팅 참여/불참시 현재 시간 검증
 테스트 코드 작성

## 💬리뷰 요구사항(선택)

> 스케줄링 설정 누락된 거 있어서 추가되었고 나머지는 어드민 미팅 조회/삭제 기능입니다.
여기에 미팅 참여에 따른 캘린더 관리 부분과 현재 시간 검증 로직을 수정/추가했습니다.
 미팅 참여 버튼 클릭시 개인의 캘린더와 비교하여 참여 가능 여부를 판단하도록 했습니다.
 이 부분 위주로 테스트 코드와 함께 봐주시면 될 것 같습니당
