### PR TITLE
[BE] 미팅 생성시 미팅 참여 정보 관리

### DIFF
--- a/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppender.java
+++ b/backend/src/main/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppender.java
@@ -3,7 +3,6 @@ package moim_today.implement.meeting.joined_meeting;
 import moim_today.global.annotation.Implement;
 import moim_today.implement.moim.joined_moim.JoinedMoimFinder;
 import moim_today.implement.schedule.schedule.ScheduleAppender;
-import moim_today.implement.schedule.schedule.ScheduleFinder;
 import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
 import moim_today.persistence.entity.meeting.meeting.MeetingJpaEntity;
 import moim_today.persistence.entity.schedule.schedule.ScheduleJpaEntity;
@@ -39,11 +38,9 @@ public class JoinedMeetingAppender {
                 ScheduleJpaEntity scheduleJpaEntity = ScheduleJpaEntity.toEntity(memberId, moimTitle, meetingJpaEntity);
                 boolean isNew = scheduleAppender.createScheduleIfNotExist(scheduleJpaEntity);
 
-                if (isNew) {
-                    JoinedMeetingJpaEntity joinedMeetingJpaEntity =
-                            JoinedMeetingJpaEntity.toEntity(meetingId, memberId, true);
-                    joinedMeetingRepository.save(joinedMeetingJpaEntity);
-                }
+                JoinedMeetingJpaEntity joinedMeetingJpaEntity =
+                        JoinedMeetingJpaEntity.toEntity(meetingId, memberId, isNew);
+                joinedMeetingRepository.save(joinedMeetingJpaEntity);
             }
         }
     }

--- a/backend/src/test/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/joined_meeting/JoinedMeetingAppenderTest.java
@@ -242,7 +242,12 @@ class JoinedMeetingAppenderTest extends ImplementTest {
 
         // then
         assertThat(scheduleRepository.count()).isEqualTo(1);
-        assertThat(joinedMeetingRepository.count()).isEqualTo(0);
+        assertThat(joinedMeetingRepository.count()).isEqualTo(1);
+
+        JoinedMeetingJpaEntity findEntity =
+                joinedMeetingRepository.getByMemberIdAndMeetingId(memberJpaEntity.getId(), meetingJpaEntity.getId());
+
+        assertThat(findEntity.isAttendance()).isFalse();
     }
 
     @DisplayName("모임 참여 정보를 바탕으로 미팅 참여 정보를 생성할 때 다른 스케줄과 겹치지 않으면 미팅에 참여한다.")
@@ -296,5 +301,10 @@ class JoinedMeetingAppenderTest extends ImplementTest {
         // then
         assertThat(scheduleRepository.count()).isEqualTo(2);
         assertThat(joinedMeetingRepository.count()).isEqualTo(1);
+
+        JoinedMeetingJpaEntity findEntity =
+                joinedMeetingRepository.getByMemberIdAndMeetingId(memberJpaEntity.getId(), meetingJpaEntity.getId());
+
+        assertThat(findEntity.isAttendance()).isTrue();
     }
 }

--- a/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
+++ b/backend/src/test/java/moim_today/implement/meeting/meeting/MeetingManagerTest.java
@@ -4,6 +4,7 @@ import moim_today.domain.meeting.enums.MeetingCategory;
 import moim_today.dto.meeting.meeting.MeetingCreateResponse;
 import moim_today.dto.meeting.meeting.MeetingCreateRequest;
 import moim_today.global.error.BadRequestException;
+import moim_today.persistence.entity.meeting.joined_meeting.JoinedMeetingJpaEntity;
 import moim_today.persistence.entity.member.MemberJpaEntity;
 import moim_today.persistence.entity.moim.joined_moim.JoinedMoimJpaEntity;
 import moim_today.persistence.entity.moim.moim.MoimJpaEntity;
@@ -311,7 +312,7 @@ class MeetingManagerTest extends ImplementTest {
 
         // then
         assertThat(meetingRepository.count()).isEqualTo(1);
-        assertThat(joinedMeetingRepository.count()).isEqualTo(0);
+        assertThat(joinedMeetingRepository.count()).isEqualTo(1);
         assertThat(scheduleRepository.count()).isEqualTo(1);
     }
 


### PR DESCRIPTION
## 📝작업 내용

> 미팅 생성시 이미 해당 스케줄에 일정이 있으면 등록하지 않는 로직은 잘 동작하는데
참여 정보 관련해서 잘 동작하지 않는 부분이 있어서 수정하였습니다.
