### PR TITLE
[BE] 대학교의 모든 학과를 조회하는 기능 최적화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,3 +1,5 @@
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+
 buildscript {
     ext {
         restdocsApiSpecVersion = '0.17.1'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,5 +1,3 @@
-import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
-
 buildscript {
     ext {
         restdocsApiSpecVersion = '0.17.1'

--- a/backend/src/main/java/moim_today/domain/department/Department.java
+++ b/backend/src/main/java/moim_today/domain/department/Department.java
@@ -30,10 +30,18 @@ public record Department(
                                                                        final List<UniversityJpaEntity> universityJpaEntities) {
         Map<Long, Set<String>> existingUniversities = new HashMap<>();
 
-        universityJpaEntities.stream()
-                .forEach(universityJpaEntity -> {
-                    existingUniversities.put(universityJpaEntity.getId(), universityAndDepartments.get(universityJpaEntity.getUniversityName()));
-                });
+        universityJpaEntities.forEach(universityJpaEntity -> {
+            Long universityId = universityJpaEntity.getId();
+            String universityName = universityJpaEntity.getUniversityName();
+
+            Set<String> departments = universityAndDepartments.get(universityName);
+
+            if (departments != null) {
+                existingUniversities.computeIfAbsent(universityId, k -> new HashSet<>())
+                        .addAll(departments);
+            }
+        });
+
 
         return existingUniversities;
     }

--- a/backend/src/main/java/moim_today/domain/department/Department.java
+++ b/backend/src/main/java/moim_today/domain/department/Department.java
@@ -12,10 +12,10 @@ public record Department(
 
     public static List<DepartmentJpaEntity> toEntities(final Map<String, Set<String>> universityAndDepartments,
                                                        final List<UniversityJpaEntity> universityJpaEntities) {
-        Map<Long, Set<String>> existingUniversities = convertToUnivIdAndDepartments(universityAndDepartments, universityJpaEntities);
+        Map<Long, Set<String>> knownUniversities = filterKnownUniversity(universityAndDepartments, universityJpaEntities);
         List<DepartmentJpaEntity> departmentJpaEntities = new ArrayList<>();
 
-        for (Map.Entry<Long, Set<String>> entrySet : existingUniversities.entrySet()) {
+        for (Map.Entry<Long, Set<String>> entrySet : knownUniversities.entrySet()) {
             for (String departmentName : entrySet.getValue()) {
                 departmentJpaEntities.add(DepartmentJpaEntity.builder()
                         .universityId(entrySet.getKey())
@@ -26,8 +26,8 @@ public record Department(
         return departmentJpaEntities;
     }
 
-    private static Map<Long, Set<String>> convertToUnivIdAndDepartments(final Map<String, Set<String>> universityAndDepartments,
-                                                                       final List<UniversityJpaEntity> universityJpaEntities) {
+    public static Map<Long, Set<String>> filterKnownUniversity(final Map<String, Set<String>> universityAndDepartments,
+                                                               final List<UniversityJpaEntity> universityJpaEntities) {
         Map<Long, Set<String>> existingUniversities = new HashMap<>();
 
         universityJpaEntities.forEach(universityJpaEntity -> {

--- a/backend/src/main/java/moim_today/implement/department/department/DepartmentAppender.java
+++ b/backend/src/main/java/moim_today/implement/department/department/DepartmentAppender.java
@@ -1,5 +1,6 @@
 package moim_today.implement.department.department;
 
+import lombok.extern.slf4j.Slf4j;
 import moim_today.domain.department.Department;
 import moim_today.global.annotation.Implement;
 import moim_today.implement.university.UniversityFinder;
@@ -14,8 +15,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static moim_today.global.constant.DepartmentConstant.DEPARTMENT_UPDATE_BATCH_SIZE;
-
+@Slf4j
 @Implement
 public class DepartmentAppender {
 
@@ -33,31 +33,18 @@ public class DepartmentAppender {
 
     @Transactional
     public void putAllDepartment() {
-        // 모든 학과 정보 조회
         List<String> allMajor = departmentFetcher.getAllMajor();
-
-        // 업데이트 할 Department 정보
         Map<String, Set<String>> departmentUpdateQueue = new ConcurrentHashMap<>();
-
         ExecutorService executorService = Executors.newFixedThreadPool(5);
+
         for (String eachMajor : allMajor) {
             executorService.execute(() -> {
-                // Major의 모든 학과 정보 가져와서 대학교와 매핑하는 departmentUpdateQueue에 저장
                 departmentFetcher.patchDepartmentQueue(departmentUpdateQueue, eachMajor);
-                // 가져온 departmentUpdateQueue로 업뎃
-                updateDepartmentsIfSizeOver(departmentUpdateQueue, DEPARTMENT_UPDATE_BATCH_SIZE.intValue());
             });
         }
         shutdownAndAwaitTermination(executorService);
-        batchUpdate(filterUniversityExistToDepartment(departmentUpdateQueue));
-    }
 
-    @Transactional
-    public synchronized void updateDepartmentsIfSizeOver(final Map<String, Set<String>> universityAndDepartments, final int size){
-        if(getTotalMapSize(universityAndDepartments) > size){
-            batchUpdate(filterUniversityExistToDepartment(universityAndDepartments));
-            universityAndDepartments.clear();
-        }
+        batchUpdate(filterKnownUniversities(departmentUpdateQueue));
     }
 
     @Transactional
@@ -66,11 +53,9 @@ public class DepartmentAppender {
     }
 
     @Transactional(readOnly = true)
-    public List<DepartmentJpaEntity> filterUniversityExistToDepartment(final Map<String, Set<String>> universityAndDepartments) {
-        // 대학교 Entity를 대학교 이름으로 가져옴
+    public List<DepartmentJpaEntity> filterKnownUniversities(final Map<String, Set<String>> universityAndDepartments) {
         List<UniversityJpaEntity> universities = universityFinder
                 .findUniversitiesByName(universityAndDepartments.keySet().stream().toList());
-        // 대학교 + 학과 정보와 대학교 Entity 정보를 추가하여 DepartmentJpaEnttiy로 변환
         return Department.toEntities(universityAndDepartments, universities);
     }
 
@@ -85,15 +70,7 @@ public class DepartmentAppender {
         }
     }
 
-    private int getTotalMapSize(final Map<String, Set<String>> mapWithSet){
-        int totalSize = 0;
-        for(Map.Entry<String, Set<String>> entry : mapWithSet.entrySet()){
-            totalSize += entry.getValue().size();
-        }
-        return totalSize;
-    }
-
-    private void shutdownAndAwaitTermination(ExecutorService executorService) {
+    private void shutdownAndAwaitTermination(final ExecutorService executorService) {
         executorService.shutdown();
         try {
             if(!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
@@ -106,4 +83,13 @@ public class DepartmentAppender {
         }
     }
 
+    private void logSizeOfMap(final Map<String, Set<String>> departmentUpdateQueue) {
+        long totalSize = 0;
+
+        for (Map.Entry<String, Set<String>> entry : departmentUpdateQueue.entrySet()) {
+            totalSize += (entry.getValue().size() * 4L);
+        }
+
+        log.debug("size of departmentUpdateQueue: {}kb", totalSize / 1024);
+    }
 }

--- a/backend/src/main/java/moim_today/implement/department/department/DepartmentFetcher.java
+++ b/backend/src/main/java/moim_today/implement/department/department/DepartmentFetcher.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static moim_today.global.constant.UniversityConstant.*;
 import static moim_today.global.constant.exception.CrawlingExceptionConstant.CRAWLING_PARSE_ERROR;
@@ -39,16 +40,14 @@ public class DepartmentFetcher {
                                      final String majorSeq){
         Map<String, Set<String>> addingMap = getDepartmentsOfUniversity(majorSeq);
         for (Map.Entry<String, Set<String>> entry : addingMap.entrySet()) {
-            baseMap.computeIfAbsent(entry.getKey(), k -> new HashSet<>()).addAll(entry.getValue());
+            baseMap.computeIfAbsent(entry.getKey(), k -> ConcurrentHashMap.newKeySet()).addAll(entry.getValue());
         }
     }
 
     private Map<String, Set<String>> getDepartmentsOfUniversity(final String majorSeq) {
         String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_UNIVERSITY_BY_DEPARTMENT_URL.value() + majorSeq;
         String response = restTemplate.getForObject(url, String.class);
-        Map<String, Set<String>> universityAndDepartments = new HashMap<>();
-        fetchAllDepartments(response, universityAndDepartments);
-        return universityAndDepartments;
+        return fetchAllDepartments(response);
     }
 
     private void fetchAllMajor(final String response, final List<String> allMajor) {
@@ -65,7 +64,8 @@ public class DepartmentFetcher {
         }
     }
 
-    private void fetchAllDepartments(final String response, final Map<String, Set<String>> universityAndDepartments) {
+    private Map<String, Set<String>> fetchAllDepartments(final String response) {
+        Map<String, Set<String>> universityAndDepartments = new HashMap<>();
         try {
             JsonNode root = objectMapper.readTree(response);
             JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
@@ -81,6 +81,7 @@ public class DepartmentFetcher {
         } catch (JsonProcessingException e) {
             throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
         }
+        return universityAndDepartments;
     }
 
     private void patchMap(final Map<String, Set<String>> universityAndDepartments, final String universityName, final String departmentName) {

--- a/backend/src/main/java/moim_today/implement/department/department/DepartmentFetcher.java
+++ b/backend/src/main/java/moim_today/implement/department/department/DepartmentFetcher.java
@@ -31,9 +31,7 @@ public class DepartmentFetcher {
     public List<String> getAllMajor() {
         String url = UNIVERSITY_API_URL.value() + apiKey + FETCH_ALL_DEPARTMENT_URL.value();
         String response = restTemplate.getForObject(url, String.class);
-        List<String> allMajor = new ArrayList<>();
-        fetchAllMajor(response, allMajor);
-        return allMajor;
+        return fetchAllMajor(response);
     }
 
     public void patchDepartmentQueue(final Map<String, Set<String>> baseMap,
@@ -50,7 +48,8 @@ public class DepartmentFetcher {
         return fetchAllDepartments(response);
     }
 
-    private void fetchAllMajor(final String response, final List<String> allMajor) {
+    private List<String> fetchAllMajor(final String response) {
+        List<String> allMajor = new ArrayList<>();
         try {
             JsonNode root = objectMapper.readTree(response);
             JsonNode content = root.path(DATA_SEARCH.value()).path(CONTENT.value());
@@ -62,6 +61,7 @@ public class DepartmentFetcher {
         } catch (JsonProcessingException e) {
             throw new InternalServerException(CRAWLING_PARSE_ERROR.message());
         }
+        return allMajor;
     }
 
     private Map<String, Set<String>> fetchAllDepartments(final String response) {

--- a/backend/src/main/java/moim_today/persistence/repository/department/department/DepartmentRepositoryImpl.java
+++ b/backend/src/main/java/moim_today/persistence/repository/department/department/DepartmentRepositoryImpl.java
@@ -38,7 +38,6 @@ public class DepartmentRepositoryImpl implements DepartmentRepository {
                 .toList();
     }
 
-    @Transactional
     @Override
     public void batchUpdate(final List<DepartmentJpaEntity> departmentJpaEntities) {
         String sql = "INSERT INTO department (university_id, department_name) VALUES (?, ?)";

--- a/backend/src/test/java/moim_today/implement/department/department/DepartmentAppenderTest.java
+++ b/backend/src/test/java/moim_today/implement/department/department/DepartmentAppenderTest.java
@@ -47,31 +47,6 @@ class DepartmentAppenderTest extends ImplementTest {
         assertThat(allDepartment.size()).isEqualTo(10);
     }
 
-    @DisplayName("Department 정보가 Size 값을 넘을 경우 batchUpdate를 실행한다")
-    @Test
-    void updateDepartmentsIfSizeOver() {
-        // given
-        Map<String, Set<String>> departmentJpaEntities = new HashMap<>();
-        departmentJpaEntities.put(UNIVERSITY_NAME.value(), new HashSet<>());
-        UniversityJpaEntity universityJpaEntity = UniversityJpaEntity.builder()
-                .universityName(UNIVERSITY_NAME.value())
-                .universityEmail(AJOU_EMAIL_DOMAIN.value())
-                .build();
-        universityRepository.save(universityJpaEntity);
-
-        for(int i = 0; i < MAX_SIZE; i++){
-            departmentJpaEntities.get(UNIVERSITY_NAME.value()).add(DEPARTMENT_NAME.value()+i);
-        }
-
-        // when
-        departmentAppender.updateDepartmentsIfSizeOver(departmentJpaEntities, DEPARTMENT_UPDATE_BATCH_SIZE.intValue());
-
-        // then
-        long universityId = universityRepository.getByName(UNIVERSITY_NAME.value()).getId();
-        assertThat(departmentRepository.findAllDepartmentOfUniversity(universityId).size())
-                .isEqualTo(MAX_SIZE);
-    }
-
     @DisplayName("학과 정보를 추가한다.")
     @Test
     void addDepartment() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71 

## 📝작업 내용

> ExecutorService를 이용한 멀티쓰레드로 대학교 크롤링 API 호출 최적화
   기존 8분 50초 걸리던 기능을 29초로 1,727% (17배) 개선❗

### 스크린샷 (선택)
![스크린샷 2024-08-31 161651](https://github.com/user-attachments/assets/930b2918-79a6-44ef-a580-3ee4a74629a8)
-  일정한 결과를 보임을 확인
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- [기존 방식 - 버퍼, 단일 쓰레드]
 기존에 학과 정보를 1000개 이상 Map에 쌓여있다면, 쌓인 정보를 데이터베이스에 저장하고 비우는 버퍼 방식을 썼었습니다. 그런데 다시 1000개를 쌓고 데이터를 저장할 때 진로정보망 API에서 학과 정보가 중복해서 들어오는 경우가 있었기 때문에 중복 검사가 필요했습니다.
 
- [개선 방식 - 버퍼 삭제, 멀티 쓰레드, Concurrent 자료구조 이용]
Set을 사용하여 애플리케이션에서 모두 저장해두고 한 번에 업데이트하는 방식으로 개선했습니다. 서버의 용량을 많이 차지 않을까 우려하여 학과 정보를 모두 담고 크기를 로그로 확인해보니 대략 78KB 차지했습니다.

- [고민 사항]
만약 멀티쓰레드를 다른 패키지에도 많이 쓰게 된다면 global util로 빼도 좋을 것 같다 생각합니다😊

closes: #71 
